### PR TITLE
Prevent empty WebView when received HTTP/304 by disabling caching.

### DIFF
--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/components/DeviceWebview.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/components/DeviceWebview.kt
@@ -32,6 +32,7 @@ import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
+import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
@@ -165,6 +166,7 @@ fun DeviceWebView(
 
                 settings.javaScriptEnabled = true
                 settings.domStorageEnabled = true
+                settings.cacheMode = WebSettings.LOAD_NO_CACHE
 
                 setDownloadListener { url, _, contentDisposition, mimetype, _ ->
                     downloadListener(device, url, contentDisposition, mimetype, currentContext)


### PR DESCRIPTION
Fixes #37