### PR TITLE
Device controls support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -122,6 +122,7 @@ dependencies {
     implementation(libs.retrofit)
     implementation(libs.retrofit2.kotlin.coroutines.adapter)
     implementation(libs.semver4j)
+    implementation(libs.kotlinx.coroutines.jdk9)
     kapt(libs.hilt.compiler)
     ksp(libs.androidx.room.compiler)
     ksp(libs.androidx.room.compiler)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,16 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        
+        <service
+            android:name=".service.DeviceControlsProviderService"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_CONTROLS"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.service.controls.ControlsProviderService" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/repository/DeviceRepository.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/repository/DeviceRepository.kt
@@ -15,6 +15,11 @@ class DeviceRepository @Inject constructor(private val deviceDao: DeviceDao) {
     }
 
     @WorkerThread
+    suspend fun findDeviceByAddress(address: String): Device? {
+        return deviceDao.findDeviceByAddress(address)
+    }
+
+    @WorkerThread
     fun findLiveDeviceByAddress(address: String): Flow<Device?> {
         return deviceDao.findLiveDeviceByAddress(address)
     }

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/service/DeviceControlsProviderService.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/service/DeviceControlsProviderService.kt
@@ -80,7 +80,8 @@ class DeviceControlsProviderService : ControlsProviderService() {
         consumer: Consumer<Int>
     ) {
         scope.launch {
-            val device = getDeviceForControlId(controlId)
+            // controlId is device address
+            val device = repository.findDeviceByAddress(controlId)
             device?.let {
                 when (action) {
                     is BooleanAction -> toggleDevicePower(device, action.newState)
@@ -102,7 +103,7 @@ class DeviceControlsProviderService : ControlsProviderService() {
     }
 
     private fun createStatefulControl(device: Device): Control {
-        val control =  Control.StatefulBuilder(device.address, createAppIntentForDevice(device))
+        val control = Control.StatefulBuilder(device.address, createAppIntentForDevice(device))
             .setTitle(device.name)
             .setDeviceType(DeviceTypes.TYPE_LIGHT)
             .setStatus(Control.STATUS_OK)
@@ -168,18 +169,6 @@ class DeviceControlsProviderService : ControlsProviderService() {
     }
 
     /**
-     * Remove any known prefixes from controlIds and return a [Device] if it exists
-     *
-     * @param controlId String in a `(optionalPrefix_)IpAddress` format
-     */
-    private suspend fun getDeviceForControlId(controlId: String): Device? {
-        val deviceAddress = controlId.removePrefix(TOGGLE_PREFIX).removePrefix(RANGE_PREFIX)
-        val device = repository.findDeviceByAddress(deviceAddress)
-
-        return device
-    }
-
-    /**
      * Create [PendingIntent] that launches device specific screen in the app
      */
     private fun createAppIntentForDevice(device: Device): PendingIntent {
@@ -226,9 +215,6 @@ class DeviceControlsProviderService : ControlsProviderService() {
 
     companion object {
         private const val TAG = "DeviceControlsProviderService"
-
-        private const val TOGGLE_PREFIX = "toggle_"
-        private const val RANGE_PREFIX = "range_"
 
         const val EXTRA_DEVICE_MAC = "device_controls_device_mac"
     }

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/service/DeviceControlsProviderService.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/service/DeviceControlsProviderService.kt
@@ -112,9 +112,9 @@ class DeviceControlsProviderService : ControlsProviderService() {
         if (device.isOnline) {
             // set status text based on state
             if (device.isPoweredOn) {
-                control.setStatusText("On")
+                control.setStatusText(applicationContext.getString(R.string.state_on))
             } else {
-                control.setStatusText("Off")
+                control.setStatusText(applicationContext.getString(R.string.state_off))
             }
 
             // and add controls
@@ -138,7 +138,7 @@ class DeviceControlsProviderService : ControlsProviderService() {
             )
         } else {
             // offline
-            control.setStatusText("Offline")
+            control.setStatusText(applicationContext.getString(R.string.state_offline))
             // set the template to toggle with forced value of off
             control.setControlTemplate(
                 ToggleTemplate(

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/service/DeviceControlsProviderService.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/service/DeviceControlsProviderService.kt
@@ -81,16 +81,19 @@ class DeviceControlsProviderService : ControlsProviderService() {
     ) {
         scope.launch {
             // controlId is device address
-            val device = repository.findDeviceByAddress(controlId)
-            device?.let {
+            repository.findDeviceByAddress(controlId)?.let { device ->
                 when (action) {
-                    is BooleanAction -> toggleDevicePower(device, action.newState)
-                    is FloatAction -> setDeviceBrightness(device, action.newValue.toInt())
+                    is BooleanAction -> {
+                        toggleDevicePower(device, action.newState)
+                        consumer.accept(ControlAction.RESPONSE_OK)
+                    }
+                    is FloatAction -> {
+                        setDeviceBrightness(device, action.newValue.toInt())
+                        consumer.accept(ControlAction.RESPONSE_OK)
+                    }
 
                     else -> consumer.accept(ControlAction.RESPONSE_FAIL)
                 }
-
-                consumer.accept(ControlAction.RESPONSE_OK)
             } ?: consumer.accept(ControlAction.RESPONSE_FAIL)
         }
     }

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/service/DeviceControlsProviderService.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/service/DeviceControlsProviderService.kt
@@ -1,0 +1,210 @@
+package ca.cgagnier.wlednativeandroid.service
+
+import android.app.PendingIntent
+import android.content.Intent
+import android.os.Build
+import android.service.controls.Control
+import android.service.controls.ControlsProviderService
+import android.service.controls.DeviceTypes
+import android.service.controls.actions.BooleanAction
+import android.service.controls.actions.ControlAction
+import android.service.controls.actions.FloatAction
+import android.service.controls.templates.ControlButton
+import android.service.controls.templates.RangeTemplate
+import android.service.controls.templates.ToggleRangeTemplate
+import androidx.annotation.RequiresApi
+import ca.cgagnier.wlednativeandroid.R
+import ca.cgagnier.wlednativeandroid.model.Device
+import ca.cgagnier.wlednativeandroid.model.wledapi.JsonPost
+import ca.cgagnier.wlednativeandroid.repository.DeviceRepository
+import ca.cgagnier.wlednativeandroid.service.device.StateFactory
+import ca.cgagnier.wlednativeandroid.service.device.api.request.StateChangeRequest
+import ca.cgagnier.wlednativeandroid.ui.MainActivity
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.jdk9.asPublisher
+import kotlinx.coroutines.launch
+import java.util.concurrent.Flow
+import java.util.function.Consumer
+import javax.inject.Inject
+
+// TODO: offline doesn't work
+
+@RequiresApi(Build.VERSION_CODES.R)
+@AndroidEntryPoint
+class DeviceControlsProviderService : ControlsProviderService() {
+    @Inject
+    lateinit var repository: DeviceRepository
+    @Inject
+    lateinit var stateFactory: StateFactory
+
+    private val job = SupervisorJob()
+    private val scope = CoroutineScope(Dispatchers.IO + job)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun createPublisherForAllAvailable(): Flow.Publisher<Control> {
+        return repository.allDevices
+            .take(1)
+                .flatMapLatest { deviceList ->
+                deviceList.asFlow()
+            }.map { device ->
+                createStatelessControl(device)
+            }.asPublisher()
+    }
+
+    override fun createPublisherFor(controlIds: List<String>): Flow.Publisher<Control> {
+        val flows = controlIds
+            .map { controlId ->
+                repository.findLiveDeviceByAddress(controlId)
+                    .map { device ->
+                        if (device != null)
+                            createStatefulControl(device)
+                        else
+                            createErrorControl(controlId)
+                    }
+            }
+
+        return flows.merge().asPublisher()
+    }
+
+    override fun performControlAction(
+        controlId: String,
+        action: ControlAction,
+        consumer: Consumer<Int>
+    ) {
+        scope.launch {
+            val device = getDeviceForControlId(controlId)
+            device?.let {
+                when (action) {
+                    is BooleanAction -> toggleDevicePower(device, action.newState)
+                    is FloatAction -> setDeviceBrightness(device, action.newValue.toInt())
+
+                    else -> consumer.accept(ControlAction.RESPONSE_FAIL)
+                }
+
+                consumer.accept(ControlAction.RESPONSE_OK)
+            } ?: consumer.accept(ControlAction.RESPONSE_FAIL)
+        }
+    }
+
+    private fun createStatelessControl(device: Device): Control {
+        return Control.StatelessBuilder(device.address, createAppIntentForDevice(device))
+            .setTitle(device.name)
+            .setDeviceType(DeviceTypes.TYPE_LIGHT)
+            .build()
+    }
+
+    private fun createStatefulControl(device: Device): Control {
+        return Control.StatefulBuilder(device.address, createAppIntentForDevice(device))
+            .setTitle(device.name)
+            .setDeviceType(DeviceTypes.TYPE_LIGHT)
+            .setStatus(Control.STATUS_OK)
+            .setControlTemplate(
+                ToggleRangeTemplate(
+                    device.address,
+                    ControlButton(
+                        device.isPoweredOn,
+                        applicationContext.getString(R.string.device_controls_control_button_action_description)
+                    ),
+                    // TODO: not sure about the mapping here
+                    RangeTemplate(
+                        device.address,
+                        1f,
+                        255f,
+                        device.brightness.toFloat(),
+                        1f,
+                        null
+                    )
+                )
+            )
+            .build()
+    }
+
+    /**
+     * Create error like control for use when corresponding device was removed in app
+     */
+    private fun createErrorControl(controlId: String): Control {
+        val intent = Intent(this, MainActivity::class.java).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        val pendingIntent = PendingIntent.getActivity(this, 0, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+
+        return Control.StatefulBuilder(controlId, pendingIntent)
+            .setTitle(applicationContext.getString(R.string.device_controls_device_not_found))
+            .setStatus(Control.STATUS_NOT_FOUND)
+            .build()
+    }
+
+    /**
+     * Remove any known prefixes from controlIds and return a [Device] if it exists
+     *
+     * @param controlId String in a `(optionalPrefix_)IpAddress` format
+     */
+    private suspend fun getDeviceForControlId(controlId: String): Device? {
+        val deviceAddress = controlId.removePrefix(TOGGLE_PREFIX).removePrefix(RANGE_PREFIX)
+        val device = repository.findDeviceByAddress(deviceAddress)
+
+        return device
+    }
+
+    /**
+     * Create [PendingIntent] that launches device specific screen in the app
+     */
+    private fun createAppIntentForDevice(device: Device): PendingIntent {
+        // TODO: we can just remove everything but numbers and be left with a string of a unique integer
+        val integerId = device.macAddress.hashCode()
+
+        val intent = Intent(this, MainActivity::class.java)     // TODO: maybe open device specific screen
+            .putExtra(EXTRA_DEVICE_MAC, device.macAddress)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        val action = PendingIntent.getActivity(
+            this,
+            integerId,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        return action
+    }
+
+    // copied from DeviceListViewModel
+    private fun toggleDevicePower(device: Device, isOn: Boolean) {
+        val deviceSetPost = JsonPost(isOn = isOn)
+        scope.launch(Dispatchers.IO) {
+            stateFactory.getState(device).requestsManager.addRequest(
+                StateChangeRequest(device, deviceSetPost)
+            )
+        }
+    }
+
+    // copied from DeviceListViewModel
+    private fun setDeviceBrightness(device: Device, brightness: Int) {
+        val deviceSetPost = JsonPost(brightness = brightness)
+        scope.launch(Dispatchers.IO) {
+            stateFactory.getState(device).requestsManager.addRequest(
+                StateChangeRequest(device, deviceSetPost)
+            )
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        job.cancel()
+    }
+
+    companion object {
+        private const val TAG = "DeviceControlsProviderService"
+
+        private const val TOGGLE_PREFIX = "toggle_"
+        private const val RANGE_PREFIX = "range_"
+
+        const val EXTRA_DEVICE_MAC = "device_controls_device_mac"
+    }
+}

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/service/DeviceControlsProviderService.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/service/DeviceControlsProviderService.kt
@@ -88,7 +88,9 @@ class DeviceControlsProviderService : ControlsProviderService() {
                         consumer.accept(ControlAction.RESPONSE_OK)
                     }
                     is FloatAction -> {
-                        setDeviceBrightness(device, action.newValue.toInt())
+                        // map 0-100% UI range to 0-255 for API
+                        val integerBrightness = action.newValue.div(100).times(255).toInt()
+                        setDeviceBrightness(device, integerBrightness)
                         consumer.accept(ControlAction.RESPONSE_OK)
                     }
 
@@ -128,14 +130,14 @@ class DeviceControlsProviderService : ControlsProviderService() {
                         device.isPoweredOn,
                         applicationContext.getString(R.string.device_controls_control_button_action_description)
                     ),
-                    // TODO: not sure about the mapping here
                     RangeTemplate(
                         device.address,
+                        0f,
+                        100f,
+                        // map 0-255 range to 0-100% for UI
+                        device.brightness.toFloat().times(100).div(255),
                         1f,
-                        255f,
-                        device.brightness.toFloat(),
-                        1f,
-                        null
+                        "%.0f%%"
                     )
                 )
             )

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/service/DeviceControlsProviderService.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/service/DeviceControlsProviderService.kt
@@ -191,24 +191,20 @@ class DeviceControlsProviderService : ControlsProviderService() {
         return action
     }
 
-    // copied from DeviceListViewModel
+    // (mostly) copied from DeviceListViewModel
     private fun toggleDevicePower(device: Device, isOn: Boolean) {
         val deviceSetPost = JsonPost(isOn = isOn)
-        scope.launch(Dispatchers.IO) {
-            stateFactory.getState(device).requestsManager.addRequest(
-                StateChangeRequest(device, deviceSetPost)
-            )
-        }
+        stateFactory.getState(device).requestsManager.addRequest(
+            StateChangeRequest(device, deviceSetPost)
+        )
     }
 
-    // copied from DeviceListViewModel
+    // (mostly) copied from DeviceListViewModel
     private fun setDeviceBrightness(device: Device, brightness: Int) {
         val deviceSetPost = JsonPost(brightness = brightness)
-        scope.launch(Dispatchers.IO) {
-            stateFactory.getState(device).requestsManager.addRequest(
-                StateChangeRequest(device, deviceSetPost)
-            )
-        }
+        stateFactory.getState(device).requestsManager.addRequest(
+            StateChangeRequest(device, deviceSetPost)
+        )
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/MainNavHost.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/MainNavHost.kt
@@ -1,18 +1,23 @@
 package ca.cgagnier.wlednativeandroid.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import ca.cgagnier.wlednativeandroid.ui.homeScreen.DeviceListDetail
 import ca.cgagnier.wlednativeandroid.ui.settingsScreen.Settings
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.Serializable
 
 @Composable
 fun MainNavHost(
-    navController: NavHostController = rememberNavController()
+    navController: NavHostController = rememberNavController(),
+    deviceMacAddress: StateFlow<String?>
 ) {
+    val currentDeviceMacAddress by deviceMacAddress.collectAsStateWithLifecycle()
     NavHost(
         navController = navController,
         startDestination = DeviceListDetailScreen,
@@ -21,7 +26,8 @@ fun MainNavHost(
             DeviceListDetail(
                 openSettings = {
                     navController.navigate(SettingsScreen)
-                }
+                },
+                deviceMacAddress = currentDeviceMacAddress
             )
         }
         composable<SettingsScreen> {

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/DeviceListDetail.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/DeviceListDetail.kt
@@ -69,6 +69,7 @@ private const val TAG = "screen_DeviceListDetail"
 fun DeviceListDetail(
     modifier: Modifier = Modifier,
     openSettings: () -> Unit,
+    deviceMacAddress: String? = null,
     viewModel: DeviceListDetailViewModel = hiltViewModel(),
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -80,6 +81,22 @@ fun DeviceListDetail(
     val navigator =
         rememberListDetailPaneScaffoldNavigator<Any>(scaffoldDirective = customScaffoldDirective)
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
+
+    // Handle navigation to specific device if provided
+    DisposableEffect(deviceMacAddress) {
+        if (deviceMacAddress != null) {
+            coroutineScope.launch {
+                val device = viewModel.findDeviceByMacAddress(deviceMacAddress)
+                if (device != null) {
+                    navigator.navigateTo(
+                        pane = ListDetailPaneScaffoldRole.Detail,
+                        contentKey = device.address
+                    )
+                }
+            }
+        }
+        onDispose { }
+    }
 
     val selectedDeviceAddress = navigator.currentDestination?.contentKey as? String ?: ""
     val selectedDevice =

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/DeviceListDetailViewModel.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/DeviceListDetailViewModel.kt
@@ -209,4 +209,7 @@ class DeviceListDetailViewModel @Inject constructor(
             false
         }
     }
+    suspend fun findDeviceByMacAddress(macAddress: String): Device? {
+        return repository.findDeviceByMacAddress(macAddress)
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,4 +77,6 @@
     <string name="downloading_file">Downloading File</string>
     <string name="help">WLED Help</string>
     <string name="support_me">Support Moustachauve</string>
+    <string name="device_controls_device_not_found">Device not found</string>
+    <string name="device_controls_control_button_action_description">Toggle</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,4 +79,7 @@
     <string name="support_me">Support Moustachauve</string>
     <string name="device_controls_device_not_found">Device not found</string>
     <string name="device_controls_control_button_action_description">Toggle</string>
+    <string name="state_on">On</string>
+    <string name="state_off">Off</string>
+    <string name="state_offline">Offline</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ roomVersion = "2.7.1"
 runtimeLivedata = "1.8.0"
 semver4j = "3.1.0"
 webkit = "1.13.0"
+kotlinxCoroutinesJdk9 = "1.10.2"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose" }
@@ -93,6 +94,7 @@ protobuf-javalite = { module = "com.google.protobuf:protobuf-javalite", version.
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit2-kotlin-coroutines-adapter = { module = "com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter", version.ref = "retrofit2KotlinCoroutinesAdapter" }
 semver4j = { module = "com.vdurmont:semver4j", version.ref = "semver4j" }
+kotlinx-coroutines-jdk9 = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-jdk9", version.ref = "kotlinxCoroutinesJdk9" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Hi,
this PR adds support for Device Controls introduced with Android 11.

Code is mostly just modified example from https://developer.android.com/develop/ui/views/device-control

It's pretty much ready to merge, a few things though:
- [x] ~~there are some hardcoded strings in the `DeviceControlsProviderService`, I'll remove them later today~~
- [ ] I didn't add any strings to `strings-fr.xml` since I don't know the language well enough to do that
- [x] ~~I'm not sure weather to show 0-255 or 0%-100% in the Device controls (there's a `TODO` for this in the code) - asking for your opinion here~~
- [x] ~~long-pressing the device in the device controls view doesn't open device specific screen (I'm not sure how to achieve that in a simple way and didn't want to mess with UI code much, maybe can be implemented later) (there are two `TODO`s for this in the code)~~
- [ ] two methods are copied straight from another ViewModel (annotated in the code) - maybe should be exported into some common utils?
- [ ] after clearing app data (or an app reinstall) first tap and hold opens `MainActivity`, but it only shows up for a split second before turning transparent. this happens before and after changes in this PS and I don't know whats causing it

probably closes https://github.com/Moustachauve/WLED-Native-Android/issues/21 (at least for people on Android 11 and higher) and helps with https://github.com/Moustachauve/WLED-Native-Android/issues/17