### PR TITLE
Fix crash when calling openUri and other improvements

### DIFF
--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/DeviceListDetail.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/DeviceListDetail.kt
@@ -361,9 +361,9 @@ fun UriHandler.openUriSafely(uri: String) {
         this.openUri(uri)
     } catch (e: IllegalArgumentException) {
         // Log the error so you can see it in Crashlytics non-fatals if you use it
-        Log.e("DeviceListDetail", "No browser found to open: $uri", e)
+        Log.e(TAG, "No browser found to open: $uri", e)
     } catch (e: Exception) {
         // Catch generic exceptions just in case OEM implementations behave weirdly
-        Log.e("DeviceListDetail", "Error opening URI: $uri", e)
+        Log.e(TAG, "Error opening URI: $uri", e)
     }
 }


### PR DESCRIPTION
This should fix this crash found in the play console:

```
Exception java.lang.IllegalArgumentException:
  at androidx.compose.ui.platform.AndroidUriHandler.openUri (AndroidUriHandler.android.kt:36)
  at ca.cgagnier.wlednativeandroid.ui.homeScreen.DeviceListDetailKt.DrawerContent$lambda$0$1$0 (DeviceListDetail.kt:288)
[...]
Caused by android.content.ActivityNotFoundException:
  at android.app.Instrumentation.checkStartActivityResult (Instrumentation.java:2244)
  at android.app.Instrumentation.execStartActivity (Instrumentation.java:1878)
  at android.app.Activity.startActivityForResult (Activity.java:5717)
  at androidx.activity.ComponentActivity.startActivityForResult (ComponentActivity.kt:675)
  at android.app.Activity.startActivityForResult (Activity.java:5675)
  at androidx.activity.ComponentActivity.startActivityForResult (ComponentActivity.kt:660)
  at android.app.Activity.startActivity (Activity.java:6177)
  at android.app.Activity.startActivity (Activity.java:6144)
  at androidx.compose.ui.platform.AndroidUriHandler.openUri (AndroidUriHandler.android.kt:34)
```