### PR TITLE
Fix: Close navigation drawer on back press

### DIFF
--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/DeviceListDetail.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/DeviceListDetail.kt
@@ -200,10 +200,10 @@ fun DeviceListDetail(
                 })
         }
 
-        // Close drawer when back button is pressed. This is to fix a state that can happen when a
-        // user navigates to another app with the drawer open and then navigates back to the app.
-        // This would cause them to be stuck in the drawer and the back button would go to the
-        // previous app instead of closing the drawer.
+        /* Close drawer when back button is pressed. This is to fix a state that can happen when a
+         * user navigates to another app with the drawer open and then navigates back to the app.
+         * This would cause them to be stuck in the drawer and the back button would go to the
+         * previous app instead of closing the drawer. */
         BackHandler(enabled = drawerState.isOpen) {
             coroutineScope.launch {
                 drawerState.close()

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/DeviceListDetail.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/DeviceListDetail.kt
@@ -1,6 +1,7 @@
 package ca.cgagnier.wlednativeandroid.ui.homeScreen
 
 import android.util.Log
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -197,7 +198,16 @@ fun DeviceListDetail(
                         }
                     }
                 })
+        }
 
+        // Close drawer when back button is pressed. This is to fix a state that can happen when a
+        // user navigates to another app with the drawer open and then navigates back to the app.
+        // This would cause them to be stuck in the drawer and the back button would go to the
+        // previous app instead of closing the drawer.
+        BackHandler(enabled = drawerState.isOpen) {
+            coroutineScope.launch {
+                drawerState.close()
+            }
         }
     }
 


### PR DESCRIPTION
Adds a `BackHandler` to the `DeviceListDetail` composable. This ensures that if the navigation drawer is open, pressing the back button will close it, preventing users from getting stuck in the drawer after navigating away from and back to the app.