### PR TITLE
feat: Add deep linking support for wled:// scheme and AP mode

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,6 +132,7 @@ dependencies {
     ksp(libs.androidx.room.compiler)
     ksp(libs.moshi.kotlin.codegen)
     testImplementation(libs.junit)
+    testImplementation(libs.robolectric)
 }
 
 protobuf {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,20 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <!-- Deep link: wled:// scheme handler -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="wled" />
+            </intent-filter>
+            <!-- Deep link: http://4.3.2.1 AP mode handler -->
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="http" android:host="4.3.2.1" />
+            </intent-filter>
         </activity>
 
         <receiver

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/domain/DeepLinkHandler.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/domain/DeepLinkHandler.kt
@@ -1,0 +1,95 @@
+package ca.cgagnier.wlednativeandroid.domain
+
+import android.content.Intent
+import android.net.Uri
+import ca.cgagnier.wlednativeandroid.model.DEFAULT_WLED_AP_IP
+import javax.inject.Inject
+
+/**
+ * Represents a parsed deep link result.
+ */
+sealed class DeepLink {
+    /** Deep link with a MAC address identifier. */
+    data class MacAddress(val mac: String) : DeepLink()
+
+    /** Deep link with a network address (IP or hostname). */
+    data class Address(val address: String) : DeepLink()
+
+    /** Deep link to AP mode (4.3.2.1). */
+    data object ApMode : DeepLink()
+}
+
+/**
+ * Handles parsing of deep links from intents.
+ *
+ * Supports:
+ * - wled://{mac_address} - e.g., wled://AABBCCDDEEFF
+ * - wled://{ip_or_hostname} - e.g., wled://192.168.1.50 or wled://wled.local
+ * - http://4.3.2.1 - Default WLED AP mode IP
+ */
+class DeepLinkHandler @Inject constructor() {
+
+    companion object {
+        private const val SCHEME_WLED = "wled"
+        private const val SCHEME_HTTP = "http"
+        private val MAC_ADDRESS_REGEX = Regex("^[0-9A-Fa-f]{12}$")
+    }
+
+    /**
+     * Parses an Intent and returns the corresponding [DeepLink] if valid.
+     *
+     * @param intent The intent to parse
+     * @return The parsed [DeepLink] or null if not a valid deep link
+     */
+    fun parseIntent(intent: Intent?): DeepLink? {
+        if (intent?.action != Intent.ACTION_VIEW) {
+            return null
+        }
+        return parseUri(intent.data)
+    }
+
+    /**
+     * Parses a URI and returns the corresponding [DeepLink] if valid.
+     *
+     * @param uri The URI to parse
+     * @return The parsed [DeepLink] or null if not a valid deep link URI
+     */
+    fun parseUri(uri: Uri?): DeepLink? {
+        uri ?: return null
+
+        return when (uri.scheme?.lowercase()) {
+            SCHEME_WLED -> parseWledScheme(uri)
+            SCHEME_HTTP -> parseHttpScheme(uri)
+            else -> null
+        }
+    }
+
+    private fun parseWledScheme(uri: Uri): DeepLink? {
+        // wled://identifier where identifier is the host
+        val identifier = uri.host?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+
+        return if (isMacAddress(identifier)) {
+            DeepLink.MacAddress(identifier.uppercase())
+        } else {
+            DeepLink.Address(identifier)
+        }
+    }
+
+    private fun parseHttpScheme(uri: Uri): DeepLink? {
+        val host = uri.host ?: return null
+
+        return if (host == DEFAULT_WLED_AP_IP) {
+            DeepLink.ApMode
+        } else {
+            null
+        }
+    }
+
+    /**
+     * Checks if the given string is a valid MAC address format (12 hex characters).
+     *
+     * @param identifier The string to check
+     * @return true if it's a valid MAC address format
+     */
+    fun isMacAddress(identifier: String): Boolean = MAC_ADDRESS_REGEX.matches(identifier)
+}

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/repository/DeviceDao.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/repository/DeviceDao.kt
@@ -31,7 +31,7 @@ interface DeviceDao {
     @Query("SELECT * FROM Device2 WHERE address = :address")
     fun findLiveDeviceByAddress(address: String): Flow<Device?>
 
-    @Query("SELECT * FROM Device2 WHERE macAddress != '' AND macAddress = :address")
+    @Query("SELECT * FROM Device2 WHERE macAddress != '' AND LOWER(macAddress) = LOWER(:address)")
     suspend fun findDeviceByMacAddress(address: String): Device?
 
     @Query("SELECT COUNT() FROM Device2 WHERE address = :address")

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/repository/DeviceRepository.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/repository/DeviceRepository.kt
@@ -15,6 +15,9 @@ class DeviceRepository @Inject constructor(private val deviceDao: DeviceDao) {
     suspend fun findDeviceByMacAddress(address: String): Device? = deviceDao.findDeviceByMacAddress(address)
 
     @WorkerThread
+    suspend fun findDeviceByAddress(address: String): Device? = deviceDao.findDeviceByAddress(address)
+
+    @WorkerThread
     suspend fun insert(device: Device) {
         deviceDao.insert(device)
     }

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/MainActivity.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/MainActivity.kt
@@ -9,12 +9,32 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import ca.cgagnier.wlednativeandroid.FileUploadContract
 import ca.cgagnier.wlednativeandroid.FileUploadContractResult
+import ca.cgagnier.wlednativeandroid.R
 import ca.cgagnier.wlednativeandroid.ui.theme.WLEDNativeTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -36,18 +56,24 @@ class MainActivity : ComponentActivity() {
             uploadMessage = null
         }
 
-    private var deviceAddress by mutableStateOf<NavigationEvent?>(null)
+    private var navigationEvent by mutableStateOf<NavigationEvent?>(null)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
-        handleIntent(intent)
+        viewModel.handleIntent(intent)
 
         setContent {
             WLEDNativeTheme {
-                MainNavHost(startDeviceAddress = deviceAddress)
+                DeepLinkStateHandler(
+                    viewModel = viewModel,
+                    onNavigate = { event ->
+                        navigationEvent = event
+                    },
+                )
+                MainNavHost(startDeviceAddress = navigationEvent)
             }
         }
         viewModel.downloadUpdateMetadata()
@@ -56,19 +82,98 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
-        handleIntent(intent)
-    }
-
-    private fun handleIntent(intent: Intent) {
-        val extraAddress = intent.getStringExtra(EXTRA_DEVICE_ADDRESS)
-        if (extraAddress != null) {
-            deviceAddress = NavigationEvent(extraAddress)
-        }
+        viewModel.handleIntent(intent)
     }
 
     companion object {
-        const val EXTRA_DEVICE_ADDRESS = "device_address"
+        const val EXTRA_DEVICE_MAC_ADDRESS = "device_mac_address"
     }
 }
 
-data class NavigationEvent(val address: String, val id: String = java.util.UUID.randomUUID().toString())
+@Composable
+private fun DeepLinkStateHandler(viewModel: MainViewModel, onNavigate: (NavigationEvent) -> Unit) {
+    val deepLinkState by viewModel.deepLinkState.collectAsStateWithLifecycle()
+
+    // Handle navigation when device is found
+    LaunchedEffect(deepLinkState) {
+        when (val state = deepLinkState) {
+            is DeepLinkState.NavigateToDevice -> {
+                onNavigate(state.event)
+                viewModel.clearDeepLinkState()
+            }
+            else -> { /* Handled by dialogs below */ }
+        }
+    }
+
+    // Show loading dialog when discovering device
+    when (val state = deepLinkState) {
+        is DeepLinkState.Loading -> {
+            DeepLinkLoadingDialog(
+                onDismiss = { viewModel.cancelDeepLink() },
+            )
+        }
+        is DeepLinkState.Error -> {
+            DeepLinkErrorDialog(
+                message = stringResource(state.messageResId, state.address),
+                onDismiss = { viewModel.clearDeepLinkState() },
+            )
+        }
+        else -> { /* Idle or NavigateToDevice - no dialog needed */ }
+    }
+}
+
+@Composable
+private fun DeepLinkLoadingDialog(onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
+        },
+        text = {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 24.dp),
+            ) {
+                CircularProgressIndicator(modifier = Modifier.size(48.dp))
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(stringResource(R.string.deep_link_loading))
+            }
+        },
+    )
+}
+
+@Composable
+private fun DeepLinkErrorDialog(message: String, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.dismiss))
+            }
+        },
+        title = { Text(stringResource(R.string.deep_link_error_title)) },
+        text = { Text(message) },
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DeepLinkLoadingDialogPreview() {
+    DeepLinkLoadingDialog(onDismiss = {})
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DeepLinkErrorDialogPreview() {
+    DeepLinkErrorDialog(
+        message = "Could not reach device at 192.168.1.50. Make sure it is powered on and connected.",
+        onDismiss = {},
+    )
+}
+
+data class NavigationEvent(val macAddress: String, val id: String = java.util.UUID.randomUUID().toString())

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/MainNavHost.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/MainNavHost.kt
@@ -20,7 +20,7 @@ fun MainNavHost(
     ) {
         composable<DeviceListDetailScreen> {
             DeviceListDetail(
-                initialDeviceAddress = startDeviceAddress,
+                initialDeviceMacAddress = startDeviceAddress,
                 openSettings = {
                     navController.navigate(SettingsScreen)
                 },

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/MainViewModel.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/MainViewModel.kt
@@ -1,13 +1,23 @@
 package ca.cgagnier.wlednativeandroid.ui
 
+import android.content.Intent
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import ca.cgagnier.wlednativeandroid.R
+import ca.cgagnier.wlednativeandroid.domain.DeepLink
+import ca.cgagnier.wlednativeandroid.domain.DeepLinkHandler
+import ca.cgagnier.wlednativeandroid.model.AP_MODE_MAC_ADDRESS
+import ca.cgagnier.wlednativeandroid.repository.DeviceRepository
 import ca.cgagnier.wlednativeandroid.repository.UserPreferencesRepository
+import ca.cgagnier.wlednativeandroid.service.DeviceFirstContactService
 import ca.cgagnier.wlednativeandroid.service.api.github.GithubApi
 import ca.cgagnier.wlednativeandroid.service.update.ReleaseService
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.util.concurrent.TimeUnit.DAYS
@@ -15,12 +25,30 @@ import javax.inject.Inject
 
 private const val TAG = "MainViewModel"
 
+/**
+ * Represents the state of deep link processing.
+ */
+sealed class DeepLinkState {
+    data object Idle : DeepLinkState()
+    data object Loading : DeepLinkState()
+    data class NavigateToDevice(val event: NavigationEvent) : DeepLinkState()
+    data class Error(val messageResId: Int, val address: String) : DeepLinkState()
+}
+
 @HiltViewModel
 class MainViewModel @Inject constructor(
     private val userPreferencesRepository: UserPreferencesRepository,
     private val releaseService: ReleaseService,
     private val githubApi: GithubApi,
+    private val deviceRepository: DeviceRepository,
+    private val deviceFirstContactService: DeviceFirstContactService,
+    private val deepLinkHandler: DeepLinkHandler,
 ) : ViewModel() {
+
+    private val _deepLinkState = MutableStateFlow<DeepLinkState>(DeepLinkState.Idle)
+    val deepLinkState: StateFlow<DeepLinkState> = _deepLinkState.asStateFlow()
+
+    private var deepLinkJob: kotlinx.coroutines.Job? = null
 
     fun downloadUpdateMetadata() {
         viewModelScope.launch(Dispatchers.IO) {
@@ -34,5 +62,119 @@ class MainViewModel @Inject constructor(
             // Set the next date to check in minimum 24 hours from now.
             userPreferencesRepository.updateLastUpdateCheckDate(now + DAYS.toMillis(1))
         }
+    }
+
+    /**
+     * Handles an intent that may contain a deep link or widget navigation.
+     *
+     * @param intent The intent to process
+     */
+    fun handleIntent(intent: Intent?) {
+        intent ?: return
+
+        // First check for widget-style intent extra (uses MAC address)
+        val extraMacAddress = intent.getStringExtra(MainActivity.EXTRA_DEVICE_MAC_ADDRESS)
+        if (extraMacAddress != null) {
+            Log.d(TAG, "Handling widget intent with MAC: $extraMacAddress")
+            navigateToDeviceByMac(extraMacAddress)
+            return
+        }
+
+        // Then check for deep link
+        val deepLink = deepLinkHandler.parseIntent(intent)
+        if (deepLink != null) {
+            Log.d(TAG, "Handling deep link: $deepLink")
+            handleDeepLink(deepLink)
+        }
+    }
+
+    /**
+     * Navigates directly to a device by its MAC address.
+     * Used by the widget for direct navigation to known devices.
+     *
+     * @param macAddress The MAC address of the device
+     */
+    private fun navigateToDeviceByMac(macAddress: String) {
+        _deepLinkState.value = DeepLinkState.NavigateToDevice(NavigationEvent(macAddress))
+    }
+
+    private fun handleDeepLink(deepLink: DeepLink) {
+        deepLinkJob?.cancel()
+        deepLinkJob = viewModelScope.launch(Dispatchers.IO) {
+            when (deepLink) {
+                is DeepLink.MacAddress -> handleMacAddressDeepLink(deepLink.mac)
+                is DeepLink.Address -> handleAddressDeepLink(deepLink.address)
+                is DeepLink.ApMode -> handleApModeDeepLink()
+            }
+        }
+    }
+
+    private suspend fun handleMacAddressDeepLink(macAddress: String) {
+        Log.d(TAG, "Looking up device by MAC: $macAddress")
+        val device = deviceRepository.findDeviceByMacAddress(macAddress)
+
+        if (device != null) {
+            Log.d(TAG, "Found device: ${device.macAddress}")
+            _deepLinkState.value = DeepLinkState.NavigateToDevice(NavigationEvent(device.macAddress))
+        } else {
+            Log.w(TAG, "Device not found for MAC: $macAddress")
+            _deepLinkState.value = DeepLinkState.Error(
+                messageResId = R.string.deep_link_error_mac_not_found,
+                address = macAddress,
+            )
+        }
+    }
+
+    private suspend fun handleAddressDeepLink(address: String) {
+        Log.d(TAG, "Looking up device by address: $address")
+
+        // First try to find existing device by address
+        val existingDevice = deviceRepository.findDeviceByAddress(address)
+        if (existingDevice != null) {
+            Log.d(TAG, "Found existing device: ${existingDevice.macAddress}")
+            _deepLinkState.value = DeepLinkState.NavigateToDevice(
+                NavigationEvent(existingDevice.macAddress),
+            )
+            return
+        }
+
+        // Device not in DB, try to discover it
+        Log.d(TAG, "Device not found, attempting first contact at: $address")
+        _deepLinkState.value = DeepLinkState.Loading
+
+        @Suppress("TooGenericExceptionCaught") // Intentional: catch all network/parsing failures
+        try {
+            val device = deviceFirstContactService.fetchAndUpsertDevice(address)
+            Log.d(TAG, "First contact successful: ${device.macAddress}")
+            _deepLinkState.value = DeepLinkState.NavigateToDevice(NavigationEvent(device.macAddress))
+        } catch (e: Exception) {
+            Log.e(TAG, "First contact failed for address: $address", e)
+            _deepLinkState.value = DeepLinkState.Error(
+                messageResId = R.string.deep_link_error_unreachable,
+                address = address,
+            )
+        }
+    }
+
+    private fun handleApModeDeepLink() {
+        Log.d(TAG, "Handling AP mode deep link")
+        // Navigate using the special AP mode MAC constant
+        _deepLinkState.value = DeepLinkState.NavigateToDevice(NavigationEvent(AP_MODE_MAC_ADDRESS))
+    }
+
+    /**
+     * Clears the deep link state after navigation has been handled.
+     */
+    fun clearDeepLinkState() {
+        _deepLinkState.value = DeepLinkState.Idle
+    }
+
+    /**
+     * Cancels the current deep link operation and clears the state.
+     */
+    fun cancelDeepLink() {
+        deepLinkJob?.cancel()
+        deepLinkJob = null
+        _deepLinkState.value = DeepLinkState.Idle
     }
 }

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/DeviceListDetail.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/DeviceListDetail.kt
@@ -74,7 +74,7 @@ private const val TAG = "screen_DeviceListDetail"
 @Composable
 fun DeviceListDetail(
     modifier: Modifier = Modifier,
-    initialDeviceAddress: NavigationEvent? = null,
+    initialDeviceMacAddress: NavigationEvent? = null,
     openSettings: () -> Unit,
     viewModel: DeviceListDetailViewModel = hiltViewModel(),
     deviceWebsocketListViewModel: DeviceWebsocketListViewModel = hiltViewModel(),
@@ -87,11 +87,11 @@ fun DeviceListDetail(
     val navigator =
         rememberListDetailPaneScaffoldNavigator<Any>(scaffoldDirective = customScaffoldDirective)
 
-    LaunchedEffect(initialDeviceAddress) {
-        if (initialDeviceAddress != null) {
+    LaunchedEffect(initialDeviceMacAddress) {
+        if (initialDeviceMacAddress != null) {
             navigator.navigateTo(
                 pane = ListDetailPaneScaffoldRole.Detail,
-                contentKey = initialDeviceAddress.address,
+                contentKey = initialDeviceMacAddress.macAddress,
             )
         }
     }

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetContent.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetContent.kt
@@ -83,7 +83,7 @@ private fun DeviceWidgetContent(data: WidgetStateData) {
         LocalContext.current,
         MainActivity::class.java,
     ).apply {
-        putExtra(MainActivity.EXTRA_DEVICE_ADDRESS, data.macAddress)
+        putExtra(MainActivity.EXTRA_DEVICE_MAC_ADDRESS, data.macAddress)
         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
     }
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -111,4 +111,10 @@
     <string name="open">Ouvrir</string>
     <string name="dismiss">Fermer</string>
     <string name="some_devices_hidden">Vous avez des appareils cachés</string>
+
+    <!-- Deep linking -->
+    <string name="deep_link_loading">Connexion à l\'appareil…</string>
+    <string name="deep_link_error_title">Appareil introuvable</string>
+    <string name="deep_link_error_mac_not_found">L\'appareil avec l\'adresse MAC %1$s n\'a pas été trouvé dans votre liste</string>
+    <string name="deep_link_error_unreachable">Impossible de joindre l\'appareil à %1$s. Assurez-vous qu\'il est allumé et connecté au réseau.</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -109,4 +109,10 @@
     <string name="open">打开</string>
     <string name="dismiss">关闭</string>
     <string name="some_devices_hidden">你有已隐藏的设备</string>
+
+    <!-- Deep linking -->
+    <string name="deep_link_loading">正在连接设备…</string>
+    <string name="deep_link_error_title">未找到设备</string>
+    <string name="deep_link_error_mac_not_found">未在列表中找到 MAC 地址为 %1$s 的设备</string>
+    <string name="deep_link_error_unreachable">无法连接到 %1$s。请确保设备已开机并连接到网络。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,4 +118,10 @@
     <string name="widget_please_configure" tools:ignore="MissingTranslation">Please configure</string>
     <string name="select_a_device" tools:ignore="MissingTranslation">Select a Device</string>
 
+    <!-- Deep linking -->
+    <string name="deep_link_loading">Connecting to device…</string>
+    <string name="deep_link_error_title">Device Not Found</string>
+    <string name="deep_link_error_mac_not_found">Device with MAC address %1$s not found in your device list</string>
+    <string name="deep_link_error_unreachable">Could not reach device at %1$s. Make sure it is powered on and connected to the network.</string>
+
 </resources>

--- a/app/src/test/java/ca/cgagnier/wlednativeandroid/domain/DeepLinkHandlerTest.kt
+++ b/app/src/test/java/ca/cgagnier/wlednativeandroid/domain/DeepLinkHandlerTest.kt
@@ -1,0 +1,225 @@
+package ca.cgagnier.wlednativeandroid.domain
+
+import android.content.Intent
+import android.net.Uri
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DeepLinkHandlerTest {
+
+    private lateinit var handler: DeepLinkHandler
+
+    @Before
+    fun setUp() {
+        handler = DeepLinkHandler()
+    }
+
+    // --- parseUri tests ---
+
+    @Test
+    fun `parseUri with wled scheme and MAC address returns MacAddress`() {
+        val uri = Uri.parse("wled://AABBCCDDEEFF")
+        val result = handler.parseUri(uri)
+
+        assertTrue(result is DeepLink.MacAddress)
+        assertEquals("AABBCCDDEEFF", (result as DeepLink.MacAddress).mac)
+    }
+
+    @Test
+    fun `parseUri with wled scheme and lowercase MAC address returns uppercase MacAddress`() {
+        val uri = Uri.parse("wled://aabbccddeeff")
+        val result = handler.parseUri(uri)
+
+        assertTrue(result is DeepLink.MacAddress)
+        assertEquals("AABBCCDDEEFF", (result as DeepLink.MacAddress).mac)
+    }
+
+    @Test
+    fun `parseUri with wled scheme and mixed case MAC address returns uppercase MacAddress`() {
+        val uri = Uri.parse("wled://AaBbCcDdEeFf")
+        val result = handler.parseUri(uri)
+
+        assertTrue(result is DeepLink.MacAddress)
+        assertEquals("AABBCCDDEEFF", (result as DeepLink.MacAddress).mac)
+    }
+
+    @Test
+    fun `parseUri with wled scheme and IPv4 address returns Address`() {
+        val uri = Uri.parse("wled://192.168.1.50")
+        val result = handler.parseUri(uri)
+
+        assertTrue(result is DeepLink.Address)
+        assertEquals("192.168.1.50", (result as DeepLink.Address).address)
+    }
+
+    @Test
+    fun `parseUri with wled scheme and hostname returns Address`() {
+        val uri = Uri.parse("wled://wled.local")
+        val result = handler.parseUri(uri)
+
+        assertTrue(result is DeepLink.Address)
+        assertEquals("wled.local", (result as DeepLink.Address).address)
+    }
+
+    @Test
+    fun `parseUri with wled scheme and complex hostname returns Address`() {
+        val uri = Uri.parse("wled://my-wled-device.home.arpa")
+        val result = handler.parseUri(uri)
+
+        assertTrue(result is DeepLink.Address)
+        assertEquals("my-wled-device.home.arpa", (result as DeepLink.Address).address)
+    }
+
+    @Test
+    fun `parseUri with http scheme and AP mode IP returns ApMode`() {
+        val uri = Uri.parse("http://4.3.2.1")
+        val result = handler.parseUri(uri)
+
+        assertTrue(result is DeepLink.ApMode)
+    }
+
+    @Test
+    fun `parseUri with http scheme and AP mode IP with path returns ApMode`() {
+        val uri = Uri.parse("http://4.3.2.1/edit")
+        val result = handler.parseUri(uri)
+
+        assertTrue(result is DeepLink.ApMode)
+    }
+
+    @Test
+    fun `parseUri with http scheme and non-AP IP returns null`() {
+        val uri = Uri.parse("http://192.168.1.50")
+        val result = handler.parseUri(uri)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `parseUri with https scheme returns null`() {
+        val uri = Uri.parse("https://4.3.2.1")
+        val result = handler.parseUri(uri)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `parseUri with unsupported scheme returns null`() {
+        val uri = Uri.parse("ftp://192.168.1.50")
+        val result = handler.parseUri(uri)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `parseUri with null returns null`() {
+        val result = handler.parseUri(null)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `parseUri with wled scheme and empty host returns null`() {
+        val uri = Uri.parse("wled://")
+        val result = handler.parseUri(uri)
+
+        assertNull(result)
+    }
+
+    // --- parseIntent tests ---
+
+    @Test
+    fun `parseIntent with ACTION_VIEW and valid wled uri returns DeepLink`() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("wled://192.168.1.50"))
+        val result = handler.parseIntent(intent)
+
+        assertTrue(result is DeepLink.Address)
+    }
+
+    @Test
+    fun `parseIntent with ACTION_MAIN returns null`() {
+        val intent = Intent(Intent.ACTION_MAIN)
+        intent.data = Uri.parse("wled://192.168.1.50")
+        val result = handler.parseIntent(intent)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `parseIntent with null intent returns null`() {
+        val result = handler.parseIntent(null)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `parseIntent with ACTION_VIEW but no data returns null`() {
+        val intent = Intent(Intent.ACTION_VIEW)
+        val result = handler.parseIntent(intent)
+
+        assertNull(result)
+    }
+
+    // --- isMacAddress tests ---
+
+    @Test
+    fun `isMacAddress with valid 12 hex chars returns true`() {
+        assertTrue(handler.isMacAddress("AABBCCDDEEFF"))
+    }
+
+    @Test
+    fun `isMacAddress with valid lowercase 12 hex chars returns true`() {
+        assertTrue(handler.isMacAddress("aabbccddeeff"))
+    }
+
+    @Test
+    fun `isMacAddress with valid mixed case 12 hex chars returns true`() {
+        assertTrue(handler.isMacAddress("AaBbCcDdEeFf"))
+    }
+
+    @Test
+    fun `isMacAddress with 11 chars returns false`() {
+        assertFalse(handler.isMacAddress("AABBCCDDEE"))
+    }
+
+    @Test
+    fun `isMacAddress with 13 chars returns false`() {
+        assertFalse(handler.isMacAddress("AABBCCDDEEFFF"))
+    }
+
+    @Test
+    fun `isMacAddress with non-hex chars returns false`() {
+        assertFalse(handler.isMacAddress("GGHHIIJJKKLL"))
+    }
+
+    @Test
+    fun `isMacAddress with colons returns false`() {
+        assertFalse(handler.isMacAddress("AA:BB:CC:DD:EE:FF"))
+    }
+
+    @Test
+    fun `isMacAddress with dashes returns false`() {
+        assertFalse(handler.isMacAddress("AA-BB-CC-DD-EE-FF"))
+    }
+
+    @Test
+    fun `isMacAddress with IP address returns false`() {
+        assertFalse(handler.isMacAddress("192.168.1.50"))
+    }
+
+    @Test
+    fun `isMacAddress with empty string returns false`() {
+        assertFalse(handler.isMacAddress(""))
+    }
+
+    @Test
+    fun `isMacAddress with hostname returns false`() {
+        assertFalse(handler.isMacAddress("wled.local"))
+    }
+}

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -748,6 +748,8 @@ style:
   UnusedPrivateMember:
     active: true
     allowedNames: ''
+    ignoreAnnotated:
+      - 'Preview'
   UnusedPrivateProperty:
     active: true
     allowedNames: '_|ignored|expected|serialVersionUID'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ semver4j = "3.1.0"
 webkit = "1.15.0"
 graphicsShapes = "1.1.0"
 truth = "1.4.5"
+robolectric = "4.16"
 detekt = "1.23.8"
 spotless = "8.1.0"
 
@@ -90,6 +91,7 @@ retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit
 retrofit2-kotlin-coroutines-adapter = { module = "com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter", version.ref = "retrofit2KotlinCoroutinesAdapter" }
 semver4j = { module = "com.vdurmont:semver4j", version.ref = "semver4j" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 protoc = { module = "com.google.protobuf:protoc", version.ref = "protobufJavalite" }
 androidx-compose-ui-geometry = { group = "androidx.compose.ui", name = "ui-geometry" }
 androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }


### PR DESCRIPTION
Implement deep linking to allow external apps and browsers to open specific WLED devices via custom URL schemes.

## Features
- Support wled://{mac_address} to navigate directly to a device
- Support wled://{ip_or_hostname} with auto-discovery for unknown devices
- Support http://4.3.2.1 for WLED AP mode access
- Dismissable loading dialog during device discovery
- Error dialog when device cannot be reached

## Changes
- Add intent filters in AndroidManifest.xml for deep link handling
- Create DeepLinkHandler domain class for parsing deep link URIs
- Add DeepLinkState sealed class in MainViewModel for state management
- Integrate with DeviceFirstContactService for auto-discovery
- Make MAC address lookup case-insensitive in DeviceDao
- Rename EXTRA_DEVICE_ADDRESS to EXTRA_DEVICE_MAC_ADDRESS for clarity
- Add French and Chinese translations for deep link strings
- Add Robolectric for unit testing Android APIs
- Configure detekt to ignore @Preview annotated functions

## Testing
- Add 25 unit tests for DeepLinkHandler (URI parsing, MAC validation)