### PR TITLE
Feat: Add dynamic coloring and previews for widgets

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -96,6 +96,8 @@ dependencies {
     implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.glance.appwidget)
     implementation(libs.androidx.glance.material3)
+    debugImplementation(libs.androidx.glance.preview)
+    debugImplementation(libs.androidx.glance.appwidget.preview)
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.lifecycle.runtime.compose)

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/theme/Theme.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/theme/Theme.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import ca.cgagnier.wlednativeandroid.model.wledapi.DeviceStateInfo
+import ca.cgagnier.wlednativeandroid.model.wledapi.State
 import ca.cgagnier.wlednativeandroid.repository.ThemeSettings
 import ca.cgagnier.wlednativeandroid.service.websocket.DeviceWithState
 import com.materialkolor.DynamicMaterialTheme
@@ -315,25 +315,11 @@ fun WLEDNativeTheme(
     }
 }
 
-private fun getColorFromDeviceState(stateInfo: DeviceStateInfo?): Int {
-    var color = android.graphics.Color.WHITE
-    if (!stateInfo?.state?.segment.isNullOrEmpty()) {
-        val colors = stateInfo.state.segment[0].colors
-        if (!colors.isNullOrEmpty()) {
-            val colorInfo = colors[0]
-            color = if (colorInfo.size in 3..4) {
-                android.graphics.Color.rgb(
-                    colorInfo[0],
-                    colorInfo[1],
-                    colorInfo[2],
-                )
-            } else {
-                android.graphics.Color.WHITE
-            }
-        }
-    }
-    return color
-}
+fun getColorFromDeviceState(state: State?): Int = state?.segment?.firstOrNull()?.colors?.firstOrNull()
+    ?.takeIf { it.size in 3..4 }
+    ?.let { (r, g, b) ->
+        android.graphics.Color.rgb(r, g, b)
+    } ?: android.graphics.Color.WHITE
 
 @Composable
 fun DeviceTheme(
@@ -351,7 +337,7 @@ fun DeviceTheme(
     }
 
     DynamicMaterialTheme(
-        seedColor = Color(getColorFromDeviceState(stateInfo)),
+        seedColor = Color(getColorFromDeviceState(stateInfo?.state)),
         isDark = darkTheme,
         style = if (device.isOnline) PaletteStyle.Vibrant else PaletteStyle.Neutral,
         animate = true,

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetContent.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetContent.kt
@@ -146,8 +146,8 @@ private fun DeviceWidgetContent(data: WidgetStateData) {
             colors = SwitchDefaults.colors(
                 checkedThumbColor = GlanceTheme.colors.primary,
                 checkedTrackColor = GlanceTheme.colors.primary,
-                uncheckedThumbColor = GlanceTheme.colors.primary,
-                uncheckedTrackColor = GlanceTheme.colors.primary,
+                uncheckedThumbColor = GlanceTheme.colors.outline,
+                uncheckedTrackColor = GlanceTheme.colors.outline,
             ),
         )
     }
@@ -203,7 +203,7 @@ private fun DeviceWidgetContentPreviewOff() {
             data = WidgetStateData(
                 macAddress = "AA:BB:CC:DD:EE:FF",
                 address = "192.168.1.101",
-                name = "WLED Status",
+                name = "Offline device",
                 isOn = false,
                 color = 0xFFFF8000.toInt(),
             ),

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetTheme.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetTheme.kt
@@ -1,0 +1,36 @@
+package ca.cgagnier.wlednativeandroid.widget
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.ui.graphics.Color
+import androidx.glance.color.ColorProviders
+import com.materialkolor.PaletteStyle
+import com.materialkolor.dynamicColorScheme
+import androidx.glance.material3.ColorProviders as createColorProviders
+
+/**
+ * Creates a [ColorProviders] for the widget themed with the device's current LED color.
+ *
+ * @param seedColor The device's current LED color to use as the seed for the color scheme
+ * @param isOnline Whether the device is currently online (affects the palette style)
+ */
+fun createDeviceColorProviders(seedColor: Color, isOnline: Boolean): ColorProviders {
+    val style = if (isOnline) PaletteStyle.Vibrant else PaletteStyle.Neutral
+
+    val lightScheme: ColorScheme = dynamicColorScheme(
+        seedColor = seedColor,
+        isDark = false,
+        style = style,
+    )
+
+    val darkScheme: ColorScheme = dynamicColorScheme(
+        seedColor = seedColor,
+        isDark = true,
+        style = style,
+        isAmoled = true, // Use deeper/more saturated colors for dark mode
+    )
+
+    return createColorProviders(
+        light = lightScheme,
+        dark = darkScheme,
+    )
+}

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WledWidgetManager.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WledWidgetManager.kt
@@ -8,9 +8,9 @@ import androidx.glance.appwidget.state.getAppWidgetState
 import androidx.glance.appwidget.state.updateAppWidgetState
 import androidx.glance.state.PreferencesGlanceStateDefinition
 import ca.cgagnier.wlednativeandroid.model.wledapi.JsonPost
-import ca.cgagnier.wlednativeandroid.model.wledapi.State
 import ca.cgagnier.wlednativeandroid.repository.DeviceRepository
 import ca.cgagnier.wlednativeandroid.service.api.DeviceApiFactory
+import ca.cgagnier.wlednativeandroid.ui.theme.getColorFromDeviceState
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
@@ -23,7 +23,6 @@ class WledWidgetManager @Inject constructor(
 ) {
     companion object {
         private const val TAG = "WledWidgetManager"
-        private const val MIN_RGB_COMPONENTS = 3
     }
 
     suspend fun updateAllWidgets(context: Context) {
@@ -76,30 +75,12 @@ class WledWidgetManager @Inject constructor(
                 val newData = widgetData.copy(
                     address = targetAddress,
                     isOn = body.isOn ?: jsonPost.isOn ?: widgetData.isOn,
-                    color = getColorFromState(body),
+                    color = getColorFromDeviceState(body),
                     lastUpdated = System.currentTimeMillis(),
                 )
                 saveStateAndPush(context, glanceId, newData)
             }
         }
-    }
-
-    private fun getColorFromState(state: State): Int {
-        val segments = state.segment
-        if (!segments.isNullOrEmpty()) {
-            val colors = segments[0].colors
-            if (!colors.isNullOrEmpty()) {
-                val colorInfo = colors[0]
-                if (colorInfo.size >= MIN_RGB_COMPONENTS) {
-                    return android.graphics.Color.rgb(
-                        colorInfo[0],
-                        colorInfo[1],
-                        colorInfo[2],
-                    )
-                }
-            }
-        }
-        return android.graphics.Color.WHITE
     }
 
     private suspend fun getWidgetState(context: Context, glanceId: GlanceId): WidgetStateData? {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ coreKtx = "1.17.0"
 coreSplashscreen = "1.2.0"
 datastorePreferences = "1.2.0"
 espressoCore = "3.7.0"
+glance = "1.1.1"
 # Version 2.53.1 causes issue with compiling
 # https://github.com/google/dagger/issues/4533
 hiltAndroid = "2.57.2"
@@ -95,8 +96,10 @@ robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectr
 protoc = { module = "com.google.protobuf:protoc", version.ref = "protobufJavalite" }
 androidx-compose-ui-geometry = { group = "androidx.compose.ui", name = "ui-geometry" }
 androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
-androidx-glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", version = "1.1.0" }
-androidx-glance-material3 = { group = "androidx.glance", name = "glance-material3", version = "1.1.0" }
+androidx-glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", version.ref = "glance" }
+androidx-glance-appwidget-preview = { group = "androidx.glance", name = "glance-appwidget-preview", version.ref = "glance" }
+androidx-glance-material3 = { group = "androidx.glance", name = "glance-material3", version.ref = "glance" }
+androidx-glance-preview = { group = "androidx.glance", name = "glance-preview", version.ref = "glance" }
 
 # TODO: Manually import the icons instead of importing this.
 compose-material-icons = { group = "androidx.compose.material", name = "material-icons-core" }


### PR DESCRIPTION
This commit introduces dynamic color theming for widgets based on the device's current LED color.

- Upgraded Glance dependencies to version 1.1.1.
- Added a new `WidgetTheme.kt` to generate dynamic `ColorProviders` from a seed color.
- Integrated the dynamic theme into `WidgetContent`, theming the widget and the power toggle switch.
- The widget's state now stores the device's primary color.
- Added `@Preview` composables to visualize the widget in both 'on' and 'off' states directly in the IDE.