### PR TITLE
CI: Optimize Gradle build and test execution

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,8 +39,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -51,14 +49,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
-      - name: Run Spotless
-        run: ./gradlew spotlessCheck
-
-      - name: Run Detekt
-        run: ./gradlew detekt
-
-      - name: Run lint
-        run: ./gradlew lintDebug
+      - name: Run Analysis
+        run: ./gradlew spotlessCheck detekt lintDebug
 
       - name: Upload Lint Results
         if: always()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -157,3 +157,11 @@ protobuf {
         }
     }
 }
+
+tasks.withType<Test>().configureEach {
+    maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).takeIf { it > 0 } ?: 1
+    // Optional: Improve console output for parallel tests
+    testLogging {
+        events("passed", "skipped", "failed")
+    }
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -155,3 +155,11 @@ protobuf {
         }
     }
 }
+
+tasks.withType<Test>().configureEach {
+    maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).takeIf { it > 0 } ?: 1
+    // Optional: Improve console output for parallel tests
+    testLogging {
+        events("passed", "skipped", "failed")
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,10 @@ plugins {
 }
 
 spotless {
-    ratchetFrom("origin/dev")
+    // Only use ratchet locally. On CI, check all files (faster than fetching git history)
+    if (System.getenv("CI").isNullOrEmpty()) {
+        ratchetFrom("origin/dev")
+    }
 
     kotlinGradle {
         target("*.kts") // Targets root build.gradle.kts and settings.gradle.kts
@@ -27,7 +30,9 @@ subprojects {
     apply(plugin = "io.gitlab.arturbosch.detekt")
 
     configure<com.diffplug.gradle.spotless.SpotlessExtension> {
-        ratchetFrom("origin/dev")
+        if (System.getenv("CI").isNullOrEmpty()) {
+            ratchetFrom("origin/dev")
+        }
 
         kotlin {
             target("**/*.kt")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #Gradle
-org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4096M"
 
 #Kotlin
 kotlin.code.style=official


### PR DESCRIPTION
- Enable parallel test execution by setting `maxParallelForks` in `app/build.gradle.kts`.
- Consolidate Spotless, Detekt, and Lint checks into a single Gradle command in the `check.yml` workflow.
- Increase the Gradle JVM heap size from 2GB to 4GB in `gradle.properties`.
- Disable Spotless's `ratchetFrom` on CI to avoid fetching git history and check all files instead.