### PR TITLE
Feat: Update widgets from WebSocket state and sync with each others

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -135,6 +135,7 @@ dependencies {
     ksp(libs.moshi.kotlin.codegen)
     testImplementation(libs.junit)
     testImplementation(libs.robolectric)
+    testImplementation(libs.mockk)
 }
 
 protobuf {

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/service/websocket/WebsocketClientFactory.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/service/websocket/WebsocketClientFactory.kt
@@ -1,0 +1,39 @@
+package ca.cgagnier.wlednativeandroid.service.websocket
+
+import android.content.Context
+import ca.cgagnier.wlednativeandroid.model.Device
+import ca.cgagnier.wlednativeandroid.repository.DeviceRepository
+import ca.cgagnier.wlednativeandroid.service.update.DeviceUpdateManager
+import ca.cgagnier.wlednativeandroid.widget.WledWidgetManager
+import com.squareup.moshi.Moshi
+import dagger.hilt.android.qualifiers.ApplicationContext
+import okhttp3.OkHttpClient
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Factory for creating WebsocketClient instances.
+ * Encapsulates the dependencies required for WebSocket connections.
+ */
+@Singleton
+class WebsocketClientFactory @Inject constructor(
+    @param:ApplicationContext private val applicationContext: Context,
+    private val deviceRepository: DeviceRepository,
+    private val widgetManager: WledWidgetManager,
+    private val deviceUpdateManager: DeviceUpdateManager,
+    private val okHttpClient: OkHttpClient,
+    private val moshi: Moshi,
+) {
+    /**
+     * Creates a new WebsocketClient for the given device.
+     */
+    fun create(device: Device): WebsocketClient = WebsocketClient(
+        device = device,
+        applicationContext = applicationContext,
+        deviceRepository = deviceRepository,
+        widgetManager = widgetManager,
+        deviceUpdateManager = deviceUpdateManager,
+        okHttpClient = okHttpClient,
+        moshi = moshi,
+    )
+}

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/list/DeviceWebsocketListViewModel.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/list/DeviceWebsocketListViewModel.kt
@@ -1,5 +1,6 @@
 package ca.cgagnier.wlednativeandroid.ui.homeScreen.list
 
+import android.content.Context
 import android.util.Log
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -13,6 +14,7 @@ import ca.cgagnier.wlednativeandroid.repository.UserPreferencesRepository
 import ca.cgagnier.wlednativeandroid.service.update.DeviceUpdateManager
 import ca.cgagnier.wlednativeandroid.service.websocket.DeviceWithState
 import ca.cgagnier.wlednativeandroid.service.websocket.WebsocketClient
+import ca.cgagnier.wlednativeandroid.widget.WledWidgetManager
 import com.squareup.moshi.Moshi
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -29,11 +31,14 @@ import javax.inject.Inject
 
 private const val TAG = "DeviceWebsocketListViewModel"
 
+@Suppress("LongParameterList")
 @HiltViewModel
 class DeviceWebsocketListViewModel @Inject constructor(
+    @param:dagger.hilt.android.qualifiers.ApplicationContext private val applicationContext: Context,
     userPreferencesRepository: UserPreferencesRepository,
     private val deviceRepository: DeviceRepository,
     private val deviceUpdateManager: DeviceUpdateManager,
+    private val widgetManager: WledWidgetManager,
     private val okHttpClient: OkHttpClient,
     private val moshi: Moshi,
 ) : ViewModel(),
@@ -82,7 +87,9 @@ class DeviceWebsocketListViewModel @Inject constructor(
                         Log.d(TAG, "[Scan] Device added: $macAddress. Creating client.")
                         val newClient = WebsocketClient(
                             device,
+                            applicationContext,
                             deviceRepository,
+                            widgetManager,
                             deviceUpdateManager,
                             okHttpClient,
                             moshi,
@@ -100,7 +107,9 @@ class DeviceWebsocketListViewModel @Inject constructor(
                         existingClient.destroy()
                         val newClient = WebsocketClient(
                             device,
+                            applicationContext,
                             deviceRepository,
+                            widgetManager,
                             deviceUpdateManager,
                             okHttpClient,
                             moshi,

--- a/app/src/test/java/ca/cgagnier/wlednativeandroid/service/websocket/WebsocketClientFactoryTest.kt
+++ b/app/src/test/java/ca/cgagnier/wlednativeandroid/service/websocket/WebsocketClientFactoryTest.kt
@@ -1,0 +1,103 @@
+package ca.cgagnier.wlednativeandroid.service.websocket
+
+import android.content.Context
+import ca.cgagnier.wlednativeandroid.model.Device
+import ca.cgagnier.wlednativeandroid.repository.DeviceRepository
+import ca.cgagnier.wlednativeandroid.service.update.DeviceUpdateManager
+import ca.cgagnier.wlednativeandroid.widget.WledWidgetManager
+import com.squareup.moshi.Moshi
+import io.mockk.mockk
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotSame
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class WebsocketClientFactoryTest {
+
+    private lateinit var context: Context
+    private lateinit var okHttpClient: OkHttpClient
+    private lateinit var moshi: Moshi
+    private lateinit var factory: WebsocketClientFactory
+
+    // Using mockk for mocking dependencies (relaxed = true ignores unstubbed calls)
+    private val deviceRepository: DeviceRepository = mockk(relaxed = true)
+    private val widgetManager: WledWidgetManager = mockk(relaxed = true)
+    private val deviceUpdateManager: DeviceUpdateManager = mockk(relaxed = true)
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        okHttpClient = OkHttpClient.Builder().build()
+        moshi = Moshi.Builder().build()
+
+        factory = WebsocketClientFactory(
+            applicationContext = context,
+            deviceRepository = deviceRepository,
+            widgetManager = widgetManager,
+            deviceUpdateManager = deviceUpdateManager,
+            okHttpClient = okHttpClient,
+            moshi = moshi,
+        )
+    }
+
+    @Test
+    fun `create returns WebsocketClient with correct device`() {
+        val device = createTestDevice("AABBCCDDEEFF", "192.168.1.100", "Test Device")
+
+        val client = factory.create(device)
+
+        assertNotNull(client)
+        assertEquals(device, client.deviceState.device)
+        assertEquals("AABBCCDDEEFF", client.deviceState.device.macAddress)
+        assertEquals("192.168.1.100", client.deviceState.device.address)
+    }
+
+    @Test
+    fun `create returns different instances for different devices`() {
+        val device1 = createTestDevice("AABBCCDDEEFF", "192.168.1.100", "Device 1")
+        val device2 = createTestDevice("112233445566", "192.168.1.101", "Device 2")
+
+        val client1 = factory.create(device1)
+        val client2 = factory.create(device2)
+
+        assertNotSame(client1, client2)
+        assertEquals("AABBCCDDEEFF", client1.deviceState.device.macAddress)
+        assertEquals("112233445566", client2.deviceState.device.macAddress)
+    }
+
+    @Test
+    fun `create preserves device properties`() {
+        val device = createTestDevice(
+            macAddress = "FFEEDDCCBBAA",
+            address = "10.0.0.50",
+            originalName = "Kitchen Lights",
+        )
+
+        val client = factory.create(device)
+
+        assertEquals("FFEEDDCCBBAA", client.deviceState.device.macAddress)
+        assertEquals("10.0.0.50", client.deviceState.device.address)
+        assertEquals("Kitchen Lights", client.deviceState.device.originalName)
+    }
+
+    @Test
+    fun `create returns client with initial disconnected status`() {
+        val device = createTestDevice("AABBCCDDEEFF", "192.168.1.100", "Test")
+
+        val client = factory.create(device)
+
+        assertEquals(WebsocketStatus.DISCONNECTED, client.deviceState.websocketStatus.value)
+    }
+
+    private fun createTestDevice(macAddress: String, address: String, originalName: String): Device = Device(
+        macAddress = macAddress,
+        address = address,
+        originalName = originalName,
+    )
+}

--- a/app/src/test/java/ca/cgagnier/wlednativeandroid/widget/WidgetStateDataTest.kt
+++ b/app/src/test/java/ca/cgagnier/wlednativeandroid/widget/WidgetStateDataTest.kt
@@ -1,0 +1,124 @@
+package ca.cgagnier.wlednativeandroid.widget
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class WidgetStateDataTest {
+
+    @Test
+    fun `WidgetStateData defaults are correct`() {
+        val data = WidgetStateData(
+            macAddress = "AABBCCDDEEFF",
+            address = "192.168.1.100",
+            name = "Test Device",
+            isOn = true,
+        )
+
+        assertEquals("AABBCCDDEEFF", data.macAddress)
+        assertEquals("192.168.1.100", data.address)
+        assertEquals("Test Device", data.name)
+        assertTrue(data.isOn)
+        assertTrue(data.isOnline) // default
+        assertEquals(-1, data.color) // default
+    }
+
+    @Test
+    fun `WidgetStateData with custom values`() {
+        val data = WidgetStateData(
+            macAddress = "112233445566",
+            address = "10.0.0.50",
+            name = "Living Room",
+            isOn = false,
+            isOnline = false,
+            color = 0xFF0000FF.toInt(),
+            batteryLevel = 85,
+            lastUpdated = 1234567890L,
+        )
+
+        assertEquals("112233445566", data.macAddress)
+        assertEquals("10.0.0.50", data.address)
+        assertEquals("Living Room", data.name)
+        assertFalse(data.isOn)
+        assertFalse(data.isOnline)
+        assertEquals(0xFF0000FF.toInt(), data.color)
+        assertEquals(85, data.batteryLevel)
+        assertEquals(1234567890L, data.lastUpdated)
+    }
+
+    @Test
+    fun `WidgetStateData copy preserves unchanged fields`() {
+        val original = WidgetStateData(
+            macAddress = "AABBCCDDEEFF",
+            address = "192.168.1.100",
+            name = "Test Device",
+            isOn = true,
+            color = 0xFFFF0000.toInt(),
+        )
+
+        val copied = original.copy(isOn = false, isOnline = false)
+
+        assertEquals(original.macAddress, copied.macAddress)
+        assertEquals(original.address, copied.address)
+        assertEquals(original.name, copied.name)
+        assertEquals(original.color, copied.color)
+        assertFalse(copied.isOn)
+        assertFalse(copied.isOnline)
+    }
+
+    @Test
+    fun `WidgetStateData lastUpdatedFormatted returns formatted date`() {
+        val data = WidgetStateData(
+            macAddress = "AABBCCDDEEFF",
+            address = "192.168.1.100",
+            name = "Test Device",
+            isOn = true,
+            lastUpdated = 1704067200000L, // Jan 1, 2024 00:00:00 UTC
+        )
+
+        // Verify it returns a non-empty formatted string
+        assertTrue(data.lastUpdatedFormatted.isNotBlank())
+    }
+
+    @Test
+    fun `WidgetStateData equality works correctly`() {
+        val data1 = WidgetStateData(
+            macAddress = "AABBCCDDEEFF",
+            address = "192.168.1.100",
+            name = "Test",
+            isOn = true,
+            lastUpdated = 1000L,
+        )
+        val data2 = WidgetStateData(
+            macAddress = "AABBCCDDEEFF",
+            address = "192.168.1.100",
+            name = "Test",
+            isOn = true,
+            lastUpdated = 1000L,
+        )
+
+        assertEquals(data1, data2)
+    }
+
+    @Test
+    fun `WidgetStateData different MAC addresses are not equal`() {
+        val data1 = WidgetStateData(
+            macAddress = "AABBCCDDEEFF",
+            address = "192.168.1.100",
+            name = "Test",
+            isOn = true,
+        )
+        val data2 = WidgetStateData(
+            macAddress = "112233445566",
+            address = "192.168.1.100",
+            name = "Test",
+            isOn = true,
+        )
+
+        assertTrue(data1 != data2)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ truth = "1.4.5"
 robolectric = "4.16"
 detekt = "1.23.8"
 spotless = "8.1.0"
+mockk = "1.14.0"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose" }
@@ -93,6 +94,7 @@ retrofit2-kotlin-coroutines-adapter = { module = "com.jakewharton.retrofit:retro
 semver4j = { module = "com.vdurmont:semver4j", version.ref = "semver4j" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 protoc = { module = "com.google.protobuf:protoc", version.ref = "protobufJavalite" }
 androidx-compose-ui-geometry = { group = "androidx.compose.ui", name = "ui-geometry" }
 androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }


### PR DESCRIPTION
This commit introduces real-time widget updates using WebSocket state information.

- Added `updateWidgetsFromDeviceState` to `WledWidgetManager` to update widgets when a device's state is received from an external source, like a WebSocket.
- The `WebsocketClient` now calls this new function to push state changes to the appropriate widgets.
- Refactored `WledWidgetManager` to have a centralized `updateWidgetsForMacAddress` function, ensuring all widgets for a single device are updated simultaneously, which improves consistency.