### PR TITLE
feat: Display last updated time as a chronometer in widgets

### DIFF
--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/ElapsedTimeChronometer.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/ElapsedTimeChronometer.kt
@@ -35,11 +35,8 @@ fun ElapsedTimeChronometer(lastUpdated: Long) {
 
     AndroidRemoteViews(
         remoteViews = RemoteViews(context.packageName, R.layout.widget_last_updated).apply {
-            // Set the base time for the chronometer to count up from
             setChronometer(R.id.chronometer, chronometerBase, null, true)
-            // Apply text color to match the theme
             setTextColor(R.id.chronometer, outlineColor)
-            // Apply tint to the history icon
             setInt(R.id.history_icon, "setColorFilter", outlineColor)
         },
     )

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/ElapsedTimeChronometer.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/ElapsedTimeChronometer.kt
@@ -1,0 +1,46 @@
+package ca.cgagnier.wlednativeandroid.widget
+
+import android.os.SystemClock
+import android.widget.RemoteViews
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.toArgb
+import androidx.glance.GlanceTheme
+import androidx.glance.LocalContext
+import androidx.glance.appwidget.AndroidRemoteViews
+import ca.cgagnier.wlednativeandroid.R
+
+/**
+ * Displays a live ticking elapsed time counter using a native Chronometer view.
+ *
+ * This uses AndroidRemoteViews to embed a legacy XML layout containing a Chronometer,
+ * which ticks independently without requiring widget recomposition.
+ *
+ * The Chronometer base is calculated by converting the wall-clock lastUpdated timestamp
+ * to the corresponding elapsedRealtime value that the Chronometer expects.
+ *
+ * @param lastUpdated The wall-clock timestamp (from System.currentTimeMillis()) to count up from.
+ */
+@Composable
+fun ElapsedTimeChronometer(lastUpdated: Long) {
+    val context = LocalContext.current
+    val outlineColor = GlanceTheme.colors.outline.getColor(context).toArgb()
+
+    // Calculate the Chronometer base:
+    // Chronometer uses SystemClock.elapsedRealtime() as reference.
+    // We need to convert our wall-clock lastUpdated to elapsedRealtime base.
+    // elapsedRealtime_at_lastUpdated = currentElapsedRealtime - (currentTime - lastUpdated)
+    val currentTime = System.currentTimeMillis()
+    val elapsedSinceUpdate = currentTime - lastUpdated
+    val chronometerBase = SystemClock.elapsedRealtime() - elapsedSinceUpdate
+
+    AndroidRemoteViews(
+        remoteViews = RemoteViews(context.packageName, R.layout.widget_last_updated).apply {
+            // Set the base time for the chronometer to count up from
+            setChronometer(R.id.chronometer, chronometerBase, null, true)
+            // Apply text color to match the theme
+            setTextColor(R.id.chronometer, outlineColor)
+            // Apply tint to the history icon
+            setInt(R.id.history_icon, "setColorFilter", outlineColor)
+        },
+    )
+}

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetContent.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetContent.kt
@@ -269,6 +269,7 @@ private fun PowerButton(data: WidgetStateData) {
             ),
         contentAlignment = Alignment.Center,
     ) {
+        // TODO: The colors should be defined directly in the appropriate states, not decided by parent?
         if (data.isOn) {
             PowerButtonOnState(glowColorProvider, buttonColor, outlineColorProvider, onButtonColor)
         } else {

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetContent.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetContent.kt
@@ -355,7 +355,7 @@ private fun ElapsedTimeChronometerContainer(lastUpdated: Long) {
     Box(
         modifier = GlanceModifier
             .fillMaxSize()
-            // Small bottom adding to be near the bottom edge, bigger end padding to be safe from the corner radius
+            // Small bottom padding to be near the bottom edge, bigger end padding to be safe from the corner radius
             .padding(bottom = 4.dp, end = 14.dp),
         contentAlignment = Alignment.BottomEnd,
     ) {

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetContent.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetContent.kt
@@ -352,12 +352,11 @@ private fun RefreshButton(modifier: GlanceModifier = GlanceModifier) {
 
 @Composable
 private fun ElapsedTimeChronometerContainer(lastUpdated: Long) {
-    // Small bottom adding to be near the bottom edge, bigger end padding to be safe from the corner radius
     Box(
         modifier = GlanceModifier
             .fillMaxSize()
-            .padding(4.dp)
-            .padding(end = 14.dp),
+            // Small bottom adding to be near the bottom edge, bigger end padding to be safe from the corner radius
+            .padding(bottom = 4.dp, end = 14.dp),
         contentAlignment = Alignment.BottomEnd,
     ) {
         ElapsedTimeChronometer(lastUpdated)

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetContent.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetContent.kt
@@ -45,6 +45,7 @@ import kotlinx.serialization.json.Json
 
 val WIDGET_DATA_KEY = stringPreferencesKey("widget_data")
 private val NARROW_WIDGET_WIDTH_THRESHOLD = 150.dp
+private val WIDGET_SAFE_PADDING = 12.dp
 
 @Composable
 fun WidgetContent(context: Context, appWidgetId: Int) {
@@ -125,18 +126,9 @@ private fun DeviceWidgetContent(data: WidgetStateData) {
 
 @Composable
 private fun DeviceWidgetContentWide(data: WidgetStateData) {
-    val intent = data.toOpenWidgetInAppIntent(LocalContext.current)
-
-    Box(
-        modifier = GlanceModifier.fillMaxSize(),
-        contentAlignment = Alignment.TopEnd,
-    ) {
+    DeviceWidgetContainer(data) {
         Row(
-            modifier = GlanceModifier
-                .fillMaxSize()
-                .background(GlanceTheme.colors.widgetBackground)
-                .padding(16.dp)
-                .clickable(actionStartActivity(intent)),
+            modifier = GlanceModifier.fillMaxSize(),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             DeviceDetailsColumn(
@@ -147,25 +139,14 @@ private fun DeviceWidgetContentWide(data: WidgetStateData) {
             // Switch stays next to content in Wide mode
             PowerButton(data)
         }
-
-        RefreshButton()
     }
 }
 
 @Composable
 private fun DeviceWidgetContentNarrow(data: WidgetStateData) {
-    val intent = data.toOpenWidgetInAppIntent(LocalContext.current)
-
-    Box(
-        modifier = GlanceModifier.fillMaxSize(),
-        contentAlignment = Alignment.TopEnd,
-    ) {
+    DeviceWidgetContainer(data) {
         Column(
-            modifier = GlanceModifier
-                .fillMaxSize()
-                .background(GlanceTheme.colors.widgetBackground)
-                .padding(8.dp)
-                .clickable(actionStartActivity(intent)),
+            modifier = GlanceModifier.fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -177,8 +158,30 @@ private fun DeviceWidgetContentNarrow(data: WidgetStateData) {
                 showAddress = false,
             )
         }
+    }
+}
+
+@Composable
+private fun DeviceWidgetContainer(data: WidgetStateData, content: @Composable () -> Unit) {
+    val intent = data.toOpenWidgetInAppIntent(LocalContext.current)
+
+    Box(
+        modifier = GlanceModifier.fillMaxSize(),
+        contentAlignment = Alignment.TopEnd,
+    ) {
+        Box(
+            modifier = GlanceModifier
+                .fillMaxSize()
+                .background(GlanceTheme.colors.widgetBackground)
+                .padding(WIDGET_SAFE_PADDING)
+                .clickable(actionStartActivity(intent)),
+            contentAlignment = Alignment.Center,
+        ) {
+            content()
+        }
 
         RefreshButton()
+        ElapsedTimeChronometerContainer(data.lastUpdated)
     }
 }
 
@@ -230,13 +233,6 @@ private fun DeviceDetailsColumn(
                 )
             }
         }
-        Text(
-            text = data.lastUpdatedFormatted,
-            style = TextStyle(
-                color = GlanceTheme.colors.outline,
-                fontSize = 10.sp,
-            ),
-        )
     }
 }
 
@@ -350,6 +346,20 @@ private fun RefreshButton(modifier: GlanceModifier = GlanceModifier) {
                 ),
             colorFilter = ColorFilter.tint(GlanceTheme.colors.outline),
         )
+    }
+}
+
+@Composable
+private fun ElapsedTimeChronometerContainer(lastUpdated: Long) {
+    // Small bottom adding to be near the bottom edge, bigger end padding to be safe from the corner radius
+    Box(
+        modifier = GlanceModifier
+            .fillMaxSize()
+            .padding(4.dp)
+            .padding(end = 14.dp),
+        contentAlignment = Alignment.BottomEnd,
+    ) {
+        ElapsedTimeChronometer(lastUpdated)
     }
 }
 

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetStateData.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetStateData.kt
@@ -1,9 +1,6 @@
 package ca.cgagnier.wlednativeandroid.widget
 
 import kotlinx.serialization.Serializable
-import java.text.DateFormat
-import java.util.Date
-import java.util.Locale
 
 @Serializable
 data class WidgetStateData(
@@ -15,13 +12,4 @@ data class WidgetStateData(
     val color: Int = -1, // Store as ARGB Int. -1 or default could indicate "unknown"
     val batteryLevel: Int? = null,
     val lastUpdated: Long = System.currentTimeMillis(),
-) {
-    val lastUpdatedFormatted: String
-        get() {
-            return DateFormat.getDateTimeInstance(
-                DateFormat.SHORT,
-                DateFormat.SHORT,
-                Locale.getDefault(),
-            ).format(Date(lastUpdated))
-        }
-}
+)

--- a/app/src/main/res/drawable/outline_history_24.xml
+++ b/app/src/main/res/drawable/outline_history_24.xml
@@ -1,11 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+
     <path
         android:fillColor="@android:color/white"
-        android:pathData="M13,3c-4.97,0 -9,4.03 -9,9L1,12l3.89,3.89 0.07,0.14L9,12L5,12c0,-3.87 3.13,-7 7,-7s7,3.13 7,7 -3.13,7 -7,7c-1.93,0 -3.68,-0.79 -4.94,-2.06l-1.42,1.42C6.93,19.66 9.29,21 12,21c4.97,0 9,-4.03 9,-9s-4.03,-9 -9,-9zM12,8v5l4.28,2.54 0.72,-1.21 -3.5,-2.08L13.5,8L12,8z"/>
+        android:pathData="M480,840Q342,840 239.5,748.5Q137,657 122,520L204,520Q218,624 296.5,692Q375,760 480,760Q597,760 678.5,678.5Q760,597 760,480Q760,363 678.5,281.5Q597,200 480,200Q411,200 351,232Q291,264 250,320L360,320L360,400L120,400L120,160L200,160L200,254Q251,190 324.5,155Q398,120 480,120Q555,120 620.5,148.5Q686,177 734.5,225.5Q783,274 811.5,339.5Q840,405 840,480Q840,555 811.5,620.5Q783,686 734.5,734.5Q686,783 620.5,811.5Q555,840 480,840ZM592,648L440,496L440,280L520,280L520,464L648,592L592,648Z" />
+
 </vector>

--- a/app/src/main/res/drawable/outline_history_24.xml
+++ b/app/src/main/res/drawable/outline_history_24.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M13,3c-4.97,0 -9,4.03 -9,9L1,12l3.89,3.89 0.07,0.14L9,12L5,12c0,-3.87 3.13,-7 7,-7s7,3.13 7,7 -3.13,7 -7,7c-1.93,0 -3.68,-0.79 -4.94,-2.06l-1.42,1.42C6.93,19.66 9.29,21 12,21c4.97,0 9,-4.03 9,-9s-4.03,-9 -9,-9zM12,8v5l4.28,2.54 0.72,-1.21 -3.5,-2.08L13.5,8L12,8z"/>
+</vector>

--- a/app/src/main/res/layout/widget_last_updated.xml
+++ b/app/src/main/res/layout/widget_last_updated.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
+
+    <ImageView
+        android:id="@+id/history_icon"
+        android:layout_width="10dp"
+        android:layout_height="10dp"
+        android:layout_marginEnd="4dp"
+        android:src="@drawable/outline_history_24"
+        android:contentDescription="@string/last_updated"
+        tools:ignore="ContentDescription" />
+
+    <Chronometer
+        android:id="@+id/chronometer"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="10sp"
+        android:countDown="false"
+        tools:text="1:42" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,6 +117,7 @@
     <string name="widget_description" tools:ignore="MissingTranslation">WLED Widget</string>
     <string name="widget_please_configure" tools:ignore="MissingTranslation">Please configure</string>
     <string name="select_a_device" tools:ignore="MissingTranslation">Select a Device</string>
+    <string name="last_updated" tools:ignore="MissingTranslation">Last Updated</string>
 
     <!-- Deep linking -->
     <string name="deep_link_loading">Connecting to device…</string>

--- a/app/src/test/java/ca/cgagnier/wlednativeandroid/widget/WidgetStateDataTest.kt
+++ b/app/src/test/java/ca/cgagnier/wlednativeandroid/widget/WidgetStateDataTest.kt
@@ -71,20 +71,6 @@ class WidgetStateDataTest {
     }
 
     @Test
-    fun `WidgetStateData lastUpdatedFormatted returns formatted date`() {
-        val data = WidgetStateData(
-            macAddress = "AABBCCDDEEFF",
-            address = "192.168.1.100",
-            name = "Test Device",
-            isOn = true,
-            lastUpdated = 1704067200000L, // Jan 1, 2024 00:00:00 UTC
-        )
-
-        // Verify it returns a non-empty formatted string
-        assertTrue(data.lastUpdatedFormatted.isNotBlank())
-    }
-
-    @Test
     fun `WidgetStateData equality works correctly`() {
         val data1 = WidgetStateData(
             macAddress = "AABBCCDDEEFF",


### PR DESCRIPTION
- Introduces an `ElapsedTimeChronometer` composable that displays a live-ticking "last updated" time.
- Uses a legacy `Chronometer` view via `AndroidRemoteViews` for efficient ticking without widget recomposition.
- Replaces the static timestamp text in the device widget with this new chronometer.
- Refactors widget content layout to use a common `DeviceWidgetContainer`.