### PR TITLE
I18n: Add French and Chinese translations for widget strings

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -112,6 +112,11 @@
     <string name="dismiss">Fermer</string>
     <string name="some_devices_hidden">Vous avez des appareils cachés</string>
 
+    <string name="widget_description">Widget WLED</string>
+    <string name="widget_please_configure">Veuillez configurer</string>
+    <string name="select_a_device">Sélectionnez un appareil</string>
+    <string name="last_updated">Dernière mise à jour</string>
+
     <!-- Deep linking -->
     <string name="deep_link_loading">Connexion à l\'appareil…</string>
     <string name="deep_link_error_title">Appareil introuvable</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -110,6 +110,11 @@
     <string name="dismiss">关闭</string>
     <string name="some_devices_hidden">你有已隐藏的设备</string>
 
+    <string name="widget_description">WLED 小部件</string>
+    <string name="widget_please_configure">请配置</string>
+    <string name="select_a_device">选择设备</string>
+    <string name="last_updated">最后更新</string>
+
     <!-- Deep linking -->
     <string name="deep_link_loading">正在连接设备…</string>
     <string name="deep_link_error_title">未找到设备</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" xmlns:tools="http://schemas.android.com/tools">
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="app_name" translatable="false">WLED</string>
     <string name="app_logo">WLED Logo</string>
     <string name="add_a_device">Add a New Device</string>
@@ -114,10 +114,10 @@
     <string name="dismiss">Dismiss</string>
     <string name="some_devices_hidden">Some of your devices are hidden</string>
     <!-- TODO: Translate the widget texts -->
-    <string name="widget_description" tools:ignore="MissingTranslation">WLED Widget</string>
-    <string name="widget_please_configure" tools:ignore="MissingTranslation">Please configure</string>
-    <string name="select_a_device" tools:ignore="MissingTranslation">Select a Device</string>
-    <string name="last_updated" tools:ignore="MissingTranslation">Last Updated</string>
+    <string name="widget_description">WLED Widget</string>
+    <string name="widget_please_configure">Please configure</string>
+    <string name="select_a_device">Select a Device</string>
+    <string name="last_updated">Last Updated</string>
 
     <!-- Deep linking -->
     <string name="deep_link_loading">Connecting to device…</string>


### PR DESCRIPTION
This commit adds French and Chinese (values-fr, values-zh) translations for widget-related strings:
- `widget_description`
- `widget_please_configure`
- `select_a_device`
- `last_updated`

It also removes the `tools:ignore="MissingTranslation"` attribute from the default English strings, as translations are now available.