### PR TITLE
Refactor: Extract drawer and utils from DeviceListDetail

### DIFF
--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/DeviceListDetail.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/DeviceListDetail.kt
@@ -1,36 +1,14 @@
 package ca.cgagnier.wlednativeandroid.ui.homeScreen
 
-import android.util.Log
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.consumeWindowInsets
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
-import androidx.compose.material3.NavigationDrawerItem
-import androidx.compose.material3.NavigationDrawerItemDefaults
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.layout.AnimatedPane
@@ -45,17 +23,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.platform.UriHandler
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import ca.cgagnier.wlednativeandroid.BuildConfig
-import ca.cgagnier.wlednativeandroid.R
 import ca.cgagnier.wlednativeandroid.model.AP_MODE_MAC_ADDRESS
 import ca.cgagnier.wlednativeandroid.service.websocket.DeviceWithState
 import ca.cgagnier.wlednativeandroid.service.websocket.getApModeDeviceWithState
@@ -65,12 +36,11 @@ import ca.cgagnier.wlednativeandroid.ui.homeScreen.deviceAdd.DeviceAdd
 import ca.cgagnier.wlednativeandroid.ui.homeScreen.deviceEdit.DeviceEdit
 import ca.cgagnier.wlednativeandroid.ui.homeScreen.list.DeviceList
 import ca.cgagnier.wlednativeandroid.ui.homeScreen.list.DeviceWebsocketListViewModel
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-private const val TAG = "screen_DeviceListDetail"
-
-@Suppress("LongMethod") // TODO: Simplify this function in the future
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
+@Suppress("LongMethod") // Navigator requires type inference, limiting extraction options
 @Composable
 fun DeviceListDetail(
     modifier: Modifier = Modifier,
@@ -86,6 +56,7 @@ fun DeviceListDetail(
     )
     val navigator =
         rememberListDetailPaneScaffoldNavigator<Any>(scaffoldDirective = customScaffoldDirective)
+    val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
 
     LaunchedEffect(initialDeviceMacAddress) {
         if (initialDeviceMacAddress != null) {
@@ -95,39 +66,23 @@ fun DeviceListDetail(
             )
         }
     }
-    val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
 
     val devices by deviceWebsocketListViewModel.allDevicesWithState.collectAsStateWithLifecycle()
     val selectedDeviceMacAddress = navigator.currentDestination?.contentKey as? String
-    // TODO: Move the selectedDevice to the ViewModel
-    val selectedDevice = remember(devices, selectedDeviceMacAddress) {
-        if (selectedDeviceMacAddress == AP_MODE_MAC_ADDRESS) {
-            return@remember getApModeDeviceWithState()
-        }
-        devices.firstOrNull { it.device.macAddress == selectedDeviceMacAddress }
-    }
+    val selectedDevice = rememberSelectedDevice(devices, selectedDeviceMacAddress)
 
     val showHiddenDevices by viewModel.showHiddenDevices.collectAsStateWithLifecycle()
     val isWLEDCaptivePortal by viewModel.isWLEDCaptivePortal.collectAsStateWithLifecycle()
     val isAddDeviceDialogVisible by viewModel.isAddDeviceDialogVisible.collectAsStateWithLifecycle()
 
-    val addDevice = { viewModel.showAddDeviceDialog() }
-
-    val navigateToDeviceDetail: (DeviceWithState) -> Unit = { device: DeviceWithState ->
+    val navigateToDetail: (DeviceWithState) -> Unit = { device ->
         coroutineScope.launch {
-            navigator.navigateTo(
-                pane = ListDetailPaneScaffoldRole.Detail,
-                contentKey = device.device.macAddress,
-            )
+            navigator.navigateTo(ListDetailPaneScaffoldRole.Detail, device.device.macAddress)
         }
     }
-
-    val navigateToDeviceEdit = { device: DeviceWithState ->
+    val navigateToEdit: (DeviceWithState) -> Unit = { device ->
         coroutineScope.launch {
-            navigator.navigateTo(
-                pane = ListDetailPaneScaffoldRole.Extra,
-                contentKey = device.device.macAddress,
-            )
+            navigator.navigateTo(ListDetailPaneScaffoldRole.Extra, device.device.macAddress)
         }
     }
 
@@ -136,22 +91,7 @@ fun DeviceListDetail(
         gesturesEnabled = drawerState.isOpen,
         drawerContent = {
             ModalDrawerSheet {
-                DrawerContent(showHiddenDevices = showHiddenDevices, addDevice = {
-                    coroutineScope.launch {
-                        addDevice()
-                        drawerState.close()
-                    }
-                }, toggleShowHiddenDevices = {
-                    coroutineScope.launch {
-                        viewModel.toggleShowHiddenDevices()
-                        drawerState.close()
-                    }
-                }, openSettings = {
-                    coroutineScope.launch {
-                        openSettings()
-                        drawerState.close()
-                    }
-                })
+                DrawerSheetContent(coroutineScope, drawerState, showHiddenDevices, viewModel, openSettings)
             }
         },
     ) {
@@ -168,37 +108,27 @@ fun DeviceListDetail(
                         DeviceList(
                             selectedDevice,
                             isWLEDCaptivePortal = isWLEDCaptivePortal,
-                            onItemClick = navigateToDeviceDetail,
-                            onAddDevice = addDevice,
-                            onShowHiddenDevices = {
-                                viewModel.toggleShowHiddenDevices()
-                            },
-                            onRefresh = {
-                                viewModel.startDiscoveryServiceTimed()
-                            },
+                            onItemClick = navigateToDetail,
+                            onAddDevice = { viewModel.showAddDeviceDialog() },
+                            onShowHiddenDevices = { viewModel.toggleShowHiddenDevices() },
+                            onRefresh = { viewModel.startDiscoveryServiceTimed() },
                             onItemEdit = {
-                                navigateToDeviceDetail(it)
-                                navigateToDeviceEdit(it)
+                                navigateToDetail(it)
+                                navigateToEdit(it)
                             },
-                            onOpenDrawer = {
-                                coroutineScope.launch {
-                                    drawerState.open()
-                                }
-                            },
+                            onOpenDrawer = { coroutineScope.launch { drawerState.open() } },
                         )
                     }
                 },
                 detailPane = {
                     AnimatedPane {
-                        SelectDeviceView()
                         selectedDevice?.let { device ->
-                            DeviceDetail(device = device, onItemEdit = {
-                                navigateToDeviceEdit(device)
-                            }, canNavigateBack = navigator.canNavigateBack(), navigateUp = {
-                                coroutineScope.launch {
-                                    navigator.navigateBack()
-                                }
-                            })
+                            DeviceDetail(
+                                device = device,
+                                onItemEdit = { navigateToEdit(device) },
+                                canNavigateBack = navigator.canNavigateBack(),
+                                navigateUp = { coroutineScope.launch { navigator.navigateBack() } },
+                            )
                         } ?: SelectDeviceView()
                     }
                 },
@@ -208,11 +138,7 @@ fun DeviceListDetail(
                             DeviceEdit(
                                 device = device,
                                 canNavigateBack = navigator.canNavigateBack(),
-                                navigateUp = {
-                                    coroutineScope.launch {
-                                        navigator.navigateBack()
-                                    }
-                                },
+                                navigateUp = { coroutineScope.launch { navigator.navigateBack() } },
                             )
                         }
                     }
@@ -220,194 +146,56 @@ fun DeviceListDetail(
             )
         }
 
-        /* Close drawer when back button is pressed. This is to fix a state that can happen when a
-         * user navigates to another app with the drawer open and then navigates back to the app.
-         * This would cause them to be stuck in the drawer and the back button would go to the
-         * previous app instead of closing the drawer. */
         BackHandler(enabled = drawerState.isOpen) {
-            coroutineScope.launch {
-                drawerState.close()
-            }
+            coroutineScope.launch { drawerState.close() }
         }
     }
 
     if (isAddDeviceDialogVisible) {
-        DeviceAdd(
-            onDismissRequest = {
-                viewModel.hideAddDeviceDialog()
-            },
-        )
+        DeviceAdd(onDismissRequest = { viewModel.hideAddDeviceDialog() })
     }
 }
 
 @Composable
-private fun DrawerContent(
+private fun rememberSelectedDevice(
+    devices: List<DeviceWithState>,
+    selectedDeviceMacAddress: String?,
+): DeviceWithState? {
+    return remember(devices, selectedDeviceMacAddress) {
+        if (selectedDeviceMacAddress == AP_MODE_MAC_ADDRESS) {
+            return@remember getApModeDeviceWithState()
+        }
+        devices.firstOrNull { it.device.macAddress == selectedDeviceMacAddress }
+    }
+}
+
+@Composable
+private fun DrawerSheetContent(
+    coroutineScope: CoroutineScope,
+    drawerState: DrawerState,
     showHiddenDevices: Boolean,
-    addDevice: () -> Unit,
-    toggleShowHiddenDevices: () -> Unit,
+    viewModel: DeviceListDetailViewModel,
     openSettings: () -> Unit,
 ) {
-    val uriHandler = LocalUriHandler.current
-    val scrollState = rememberScrollState()
-
-    Column(
-        modifier = Modifier.verticalScroll(scrollState),
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            horizontalArrangement = Arrangement.Center,
-        ) {
-            Image(
-                painter = painterResource(id = R.drawable.wled_logo_akemi),
-                contentDescription = stringResource(R.string.app_logo),
-            )
-        }
-        NavigationDrawerItem(
-            label = { Text(text = stringResource(R.string.add_a_device)) },
-            icon = {
-                Icon(
-                    imageVector = Icons.Filled.Add,
-                    contentDescription = stringResource(R.string.add_a_device),
-                )
-            },
-            selected = false,
-            onClick = addDevice,
-            modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
-        )
-        ToggleHiddenDeviceButton(showHiddenDevices, toggleShowHiddenDevices)
-        NavigationDrawerItem(
-            label = { Text(text = stringResource(R.string.settings)) },
-            icon = {
-                Icon(
-                    imageVector = Icons.Filled.Settings,
-                    contentDescription = stringResource(R.string.settings),
-                )
-            },
-            selected = false,
-            onClick = openSettings,
-            modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
-        )
-        HorizontalDivider(modifier = Modifier.padding(12.dp))
-
-        NavigationDrawerItem(
-            label = { Text(text = stringResource(R.string.help)) },
-            icon = {
-                Icon(
-                    painter = painterResource(id = R.drawable.baseline_help_24),
-                    contentDescription = stringResource(R.string.help),
-                )
-            },
-            selected = false,
-            onClick = {
-                uriHandler.openUriSafely("https://kno.wled.ge/")
-            },
-            modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
-        )
-        NavigationDrawerItem(
-            label = { Text(text = stringResource(R.string.support_me)) },
-            icon = {
-                Icon(
-                    painter = painterResource(id = R.drawable.baseline_coffee_24),
-                    contentDescription = stringResource(R.string.support_me),
-                )
-            },
-            selected = false,
-            onClick = {
-                uriHandler.openUriSafely("https://github.com/sponsors/Moustachauve")
-            },
-            modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
-        )
-        Spacer(Modifier.height(24.dp))
-        Column(
-            modifier = Modifier
-                .padding(16.dp)
-                .fillMaxWidth(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            val debugString =
-                if (BuildConfig.BUILD_TYPE != "release") " - ${BuildConfig.BUILD_TYPE}" else ""
-            Text(
-                "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})$debugString",
-                style = MaterialTheme.typography.bodyMedium,
-            )
-            Text(
-                BuildConfig.APPLICATION_ID,
-                style = MaterialTheme.typography.bodySmall,
-            )
-        }
-    }
-}
-
-@Composable
-private fun ToggleHiddenDeviceButton(showHiddenDevices: Boolean, toggleShowHiddenDevices: () -> Unit) {
-    val hiddenDeviceText = stringResource(
-        if (showHiddenDevices) {
-            R.string.hide_hidden_devices
-        } else {
-            R.string.show_hidden_devices
+    DrawerContent(
+        showHiddenDevices = showHiddenDevices,
+        addDevice = {
+            coroutineScope.launch {
+                viewModel.showAddDeviceDialog()
+                drawerState.close()
+            }
+        },
+        toggleShowHiddenDevices = {
+            coroutineScope.launch {
+                viewModel.toggleShowHiddenDevices()
+                drawerState.close()
+            }
+        },
+        openSettings = {
+            coroutineScope.launch {
+                openSettings()
+                drawerState.close()
+            }
         },
     )
-    val hiddenDeviceIcon = painterResource(
-        if (showHiddenDevices) {
-            R.drawable.ic_baseline_visibility_off_24
-        } else {
-            R.drawable.baseline_visibility_24
-        },
-    )
-    NavigationDrawerItem(
-        label = { Text(text = hiddenDeviceText) },
-        icon = {
-            Icon(
-                painter = hiddenDeviceIcon,
-                contentDescription = stringResource(R.string.show_hidden_devices),
-            )
-        },
-        selected = false,
-        onClick = toggleShowHiddenDevices,
-        modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
-    )
-}
-
-@Composable
-fun SelectDeviceView() {
-    Card(
-        modifier = Modifier.padding(top = TopAppBarDefaults.MediumAppBarCollapsedHeight),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainer,
-        ),
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(top = 44.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Image(
-                painter = painterResource(id = R.drawable.wled_logo_akemi),
-                contentDescription = stringResource(R.string.app_logo),
-            )
-            Text(stringResource(R.string.select_a_device_from_the_list))
-        }
-    }
-}
-
-// TODO: Move this to a utility file or somewhere else, maybe.
-
-/**
- * Open Uri in external browser and do error handling.
- *
- * Errors can happen if, for some reason, a user doesn't have any browser installed, for example.
- */
-fun UriHandler.openUriSafely(uri: String) {
-    try {
-        this.openUri(uri)
-    } catch (e: IllegalArgumentException) {
-        // Log the error so you can see it in Crashlytics non-fatals if you use it
-        Log.e(TAG, "No browser found to open: $uri", e)
-    } catch (e: Exception) {
-        // Catch generic exceptions just in case OEM implementations behave weirdly
-        Log.e(TAG, "Error opening URI: $uri", e)
-    }
 }

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/DrawerContent.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/DrawerContent.kt
@@ -1,0 +1,182 @@
+package ca.cgagnier.wlednativeandroid.ui.homeScreen
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.NavigationDrawerItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import ca.cgagnier.wlednativeandroid.BuildConfig
+import ca.cgagnier.wlednativeandroid.R
+import ca.cgagnier.wlednativeandroid.util.openUriSafely
+
+@Composable
+internal fun DrawerContent(
+    showHiddenDevices: Boolean,
+    addDevice: () -> Unit,
+    toggleShowHiddenDevices: () -> Unit,
+    openSettings: () -> Unit,
+) {
+    val uriHandler = LocalUriHandler.current
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = Modifier.verticalScroll(scrollState),
+    ) {
+        DrawerHeader()
+        DrawerMainActions(addDevice, showHiddenDevices, toggleShowHiddenDevices, openSettings)
+        HorizontalDivider(modifier = Modifier.padding(12.dp))
+        DrawerExternalLinks(uriHandler)
+        Spacer(Modifier.height(24.dp))
+        DrawerVersionInfo()
+    }
+}
+
+@Composable
+private fun DrawerHeader() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        horizontalArrangement = Arrangement.Center,
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.wled_logo_akemi),
+            contentDescription = stringResource(R.string.app_logo),
+        )
+    }
+}
+
+@Composable
+private fun DrawerMainActions(
+    addDevice: () -> Unit,
+    showHiddenDevices: Boolean,
+    toggleShowHiddenDevices: () -> Unit,
+    openSettings: () -> Unit,
+) {
+    NavigationDrawerItem(
+        label = { Text(text = stringResource(R.string.add_a_device)) },
+        icon = {
+            Icon(
+                imageVector = Icons.Filled.Add,
+                contentDescription = stringResource(R.string.add_a_device),
+            )
+        },
+        selected = false,
+        onClick = addDevice,
+        modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
+    )
+    ToggleHiddenDeviceButton(showHiddenDevices, toggleShowHiddenDevices)
+    NavigationDrawerItem(
+        label = { Text(text = stringResource(R.string.settings)) },
+        icon = {
+            Icon(
+                imageVector = Icons.Filled.Settings,
+                contentDescription = stringResource(R.string.settings),
+            )
+        },
+        selected = false,
+        onClick = openSettings,
+        modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
+    )
+}
+
+@Composable
+private fun DrawerExternalLinks(uriHandler: UriHandler) {
+    NavigationDrawerItem(
+        label = { Text(text = stringResource(R.string.help)) },
+        icon = {
+            Icon(
+                painter = painterResource(id = R.drawable.baseline_help_24),
+                contentDescription = stringResource(R.string.help),
+            )
+        },
+        selected = false,
+        onClick = { uriHandler.openUriSafely("https://kno.wled.ge/") },
+        modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
+    )
+    NavigationDrawerItem(
+        label = { Text(text = stringResource(R.string.support_me)) },
+        icon = {
+            Icon(
+                painter = painterResource(id = R.drawable.baseline_coffee_24),
+                contentDescription = stringResource(R.string.support_me),
+            )
+        },
+        selected = false,
+        onClick = { uriHandler.openUriSafely("https://github.com/sponsors/Moustachauve") },
+        modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
+    )
+}
+
+@Composable
+private fun DrawerVersionInfo() {
+    Column(
+        modifier = Modifier
+            .padding(16.dp)
+            .fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        val debugString =
+            if (BuildConfig.BUILD_TYPE != "release") " - ${BuildConfig.BUILD_TYPE}" else ""
+        Text(
+            "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})$debugString",
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Text(
+            BuildConfig.APPLICATION_ID,
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}
+
+@Composable
+private fun ToggleHiddenDeviceButton(showHiddenDevices: Boolean, toggleShowHiddenDevices: () -> Unit) {
+    val hiddenDeviceText = stringResource(
+        if (showHiddenDevices) {
+            R.string.hide_hidden_devices
+        } else {
+            R.string.show_hidden_devices
+        },
+    )
+    val hiddenDeviceIcon = painterResource(
+        if (showHiddenDevices) {
+            R.drawable.ic_baseline_visibility_off_24
+        } else {
+            R.drawable.baseline_visibility_24
+        },
+    )
+    NavigationDrawerItem(
+        label = { Text(text = hiddenDeviceText) },
+        icon = {
+            Icon(
+                painter = hiddenDeviceIcon,
+                contentDescription = stringResource(R.string.show_hidden_devices),
+            )
+        },
+        selected = false,
+        onClick = toggleShowHiddenDevices,
+        modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
+    )
+}

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/SelectDeviceView.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/SelectDeviceView.kt
@@ -1,0 +1,41 @@
+package ca.cgagnier.wlednativeandroid.ui.homeScreen
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import ca.cgagnier.wlednativeandroid.R
+
+@Composable
+fun SelectDeviceView() {
+    Card(
+        modifier = Modifier.padding(top = TopAppBarDefaults.MediumAppBarCollapsedHeight),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = 44.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.wled_logo_akemi),
+                contentDescription = stringResource(R.string.app_logo),
+            )
+            Text(stringResource(R.string.select_a_device_from_the_list))
+        }
+    }
+}

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/util/UriUtils.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/util/UriUtils.kt
@@ -1,0 +1,22 @@
+package ca.cgagnier.wlednativeandroid.util
+
+import android.content.ActivityNotFoundException
+import android.util.Log
+import androidx.compose.ui.platform.UriHandler
+
+private const val TAG = "UriUtils"
+
+/**
+ * Open Uri in external browser with error handling.
+ *
+ * Errors can happen if, for example, a user doesn't have any browser installed.
+ */
+fun UriHandler.openUriSafely(uri: String) {
+    try {
+        this.openUri(uri)
+    } catch (e: IllegalArgumentException) {
+        Log.e(TAG, "Invalid URI: $uri", e)
+    } catch (e: ActivityNotFoundException) {
+        Log.e(TAG, "No browser found to open: $uri", e)
+    }
+}

--- a/app/src/test/java/ca/cgagnier/wlednativeandroid/util/UriUtilsTest.kt
+++ b/app/src/test/java/ca/cgagnier/wlednativeandroid/util/UriUtilsTest.kt
@@ -1,0 +1,48 @@
+package ca.cgagnier.wlednativeandroid.util
+
+import android.content.ActivityNotFoundException
+import androidx.compose.ui.platform.UriHandler
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class UriUtilsTest {
+
+    @Test
+    fun `openUriSafely calls openUri with correct uri`() {
+        val mockUriHandler = mockk<UriHandler>(relaxed = true)
+        val testUri = "https://example.com"
+
+        mockUriHandler.openUriSafely(testUri)
+
+        verify { mockUriHandler.openUri(testUri) }
+    }
+
+    @Test
+    fun `openUriSafely handles IllegalArgumentException without crashing`() {
+        val mockUriHandler = mockk<UriHandler>()
+        val testUri = "https://example.com"
+        every { mockUriHandler.openUri(any()) } throws IllegalArgumentException("Invalid URI")
+
+        // Should not throw
+        mockUriHandler.openUriSafely(testUri)
+
+        verify { mockUriHandler.openUri(testUri) }
+    }
+
+    @Test
+    fun `openUriSafely handles ActivityNotFoundException without crashing`() {
+        val mockUriHandler = mockk<UriHandler>()
+        val testUri = "https://example.com"
+        every { mockUriHandler.openUri(any()) } throws ActivityNotFoundException("No browser found")
+
+        // Should not throw
+        mockUriHandler.openUriSafely(testUri)
+
+        verify { mockUriHandler.openUri(testUri) }
+    }
+}


### PR DESCRIPTION
- Extracted `DrawerContent`, `SelectDeviceView`, and `UriUtils` from `DeviceListDetail.kt` into their own files.
- Introduced `openUriSafely` extension function for `UriHandler` to gracefully handle `IllegalArgumentException` and `ActivityNotFoundException` when opening URIs.
- Added unit tests for the new `UriUtils`.
- Simplified lambdas and function calls within `DeviceListDetail.kt`.