### PR TITLE
feat: Add Android 11 Device Controls

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -123,6 +123,7 @@ dependencies {
     implementation(libs.datastore.preferences)
     implementation(libs.hilt.android)
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.coroutines.jdk9)
     implementation(libs.lifecycle.viewmodel.ktx)
     implementation(libs.logging.interceptor)
     implementation(libs.material.kolor)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
@@ -68,6 +69,18 @@
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>
         </activity>
+
+        <!-- Device Controls (Quick Access) service for Android 11+ -->
+        <service
+            android:name=".service.controls.WledControlsService"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_CONTROLS"
+            android:exported="true"
+            tools:targetApi="30">
+            <intent-filter>
+                <action android:name="android.service.controls.ControlsProviderService" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/domain/DeepLinkHandler.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/domain/DeepLinkHandler.kt
@@ -1,8 +1,11 @@
 package ca.cgagnier.wlednativeandroid.domain
 
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import androidx.core.net.toUri
 import ca.cgagnier.wlednativeandroid.model.DEFAULT_WLED_AP_IP
+import ca.cgagnier.wlednativeandroid.ui.MainActivity
 import javax.inject.Inject
 
 /**
@@ -33,6 +36,19 @@ class DeepLinkHandler @Inject constructor() {
         private const val SCHEME_WLED = "wled"
         private const val SCHEME_HTTP = "http"
         private val MAC_ADDRESS_REGEX = Regex("^[0-9A-Fa-f]{12}$")
+
+        /**
+         * Creates an Intent to open the app with the specified device.
+         * This is shared between widgets, device controls, and other launch points.
+         *
+         * @param context The context to create the intent with
+         * @param macAddress The device's MAC address
+         * @return An Intent configured to open the device in the app
+         */
+        fun createDeviceIntent(context: Context, macAddress: String): Intent =
+            Intent(Intent.ACTION_VIEW, "$SCHEME_WLED://$macAddress".toUri())
+                .setClass(context, MainActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
     }
 
     /**

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/service/controls/WledControlsService.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/service/controls/WledControlsService.kt
@@ -14,6 +14,7 @@ import android.service.controls.templates.ControlButton
 import android.service.controls.templates.ToggleRangeTemplate
 import android.util.Log
 import androidx.annotation.RequiresApi
+import ca.cgagnier.wlednativeandroid.R
 import ca.cgagnier.wlednativeandroid.domain.DeepLinkHandler
 import ca.cgagnier.wlednativeandroid.model.Device
 import ca.cgagnier.wlednativeandroid.model.wledapi.JsonPost
@@ -298,7 +299,10 @@ class WledControlsService : ControlsProviderService() {
 
         val template = ToggleRangeTemplate(
             device.macAddress,
-            ControlButton(state.isOn, if (state.isOn) "On" else "Off"),
+            ControlButton(
+                state.isOn,
+                getString(if (state.isOn) R.string.control_on else R.string.control_off),
+            ),
             /* range = */
             android.service.controls.templates.RangeTemplate(
                 "${device.macAddress}_range",

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/service/controls/WledControlsService.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/service/controls/WledControlsService.kt
@@ -1,0 +1,300 @@
+package ca.cgagnier.wlednativeandroid.service.controls
+
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.res.ColorStateList
+import android.graphics.Color
+import android.os.Build
+import android.service.controls.Control
+import android.service.controls.ControlsProviderService
+import android.service.controls.DeviceTypes
+import android.service.controls.actions.BooleanAction
+import android.service.controls.actions.ControlAction
+import android.service.controls.actions.FloatAction
+import android.service.controls.templates.ControlButton
+import android.service.controls.templates.ToggleRangeTemplate
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.core.net.toUri
+import ca.cgagnier.wlednativeandroid.model.Device
+import ca.cgagnier.wlednativeandroid.model.wledapi.JsonPost
+import ca.cgagnier.wlednativeandroid.model.wledapi.State
+import ca.cgagnier.wlednativeandroid.repository.DeviceRepository
+import ca.cgagnier.wlednativeandroid.service.api.DeviceApiFactory
+import ca.cgagnier.wlednativeandroid.ui.MainActivity
+import ca.cgagnier.wlednativeandroid.ui.theme.getColorFromDeviceState
+import ca.cgagnier.wlednativeandroid.util.MAX_BRIGHTNESS_PERCENT
+import ca.cgagnier.wlednativeandroid.util.brightnessToPercent
+import ca.cgagnier.wlednativeandroid.util.percentToBrightness
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.jdk9.asPublisher
+import kotlinx.coroutines.launch
+import java.util.concurrent.Flow
+import java.util.function.Consumer
+
+/**
+ * Android Device Controls (Quick Access) service for WLED devices.
+ *
+ * Provides controls in the Quick Settings panel to toggle lights on/off
+ * and adjust brightness. Available on Android 11 (API 30) and above.
+ */
+@RequiresApi(Build.VERSION_CODES.R)
+class WledControlsService : ControlsProviderService() {
+
+    companion object {
+        private const val TAG = "WledControlsService"
+        private const val BRIGHTNESS_STEP = 1f
+        private const val BRIGHTNESS_FORMAT = "%.0f%%"
+    }
+
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface ControlsEntryPoint {
+        fun deviceRepository(): DeviceRepository
+        fun deviceApiFactory(): DeviceApiFactory
+    }
+
+    private val job = SupervisorJob()
+    private val scope = CoroutineScope(Dispatchers.IO + job)
+
+    private val controlFlows = mutableMapOf<String, MutableSharedFlow<Control>>()
+
+    // Cache for device state (on/off and brightness)
+    private val deviceStates = mutableMapOf<String, DeviceControlState>()
+
+    private val entryPoint: ControlsEntryPoint by lazy {
+        EntryPointAccessors.fromApplication(applicationContext, ControlsEntryPoint::class.java)
+    }
+
+    private val deviceRepository: DeviceRepository
+        get() = entryPoint.deviceRepository()
+
+    private val deviceApiFactory: DeviceApiFactory
+        get() = entryPoint.deviceApiFactory()
+
+    override fun createPublisherForAllAvailable(): Flow.Publisher<Control> = kotlinx.coroutines.flow.flow {
+        val devices = deviceRepository.getAllDevices()
+        Log.d(TAG, "createPublisherForAllAvailable: Found ${devices.size} devices")
+        devices.forEach { device ->
+            emit(createStatelessControl(device))
+        }
+    }.flowOn(Dispatchers.IO).asPublisher()
+
+    override fun createPublisherFor(controlIds: List<String>): Flow.Publisher<Control> {
+        Log.d(TAG, "createPublisherFor: ${controlIds.size} controls")
+
+        val flow = MutableSharedFlow<Control>(replay = controlIds.size, extraBufferCapacity = controlIds.size)
+        controlIds.forEach { controlFlows[it] = flow }
+
+        scope.launch {
+            controlIds.forEach { controlId ->
+                val device = deviceRepository.findDeviceByMacAddress(controlId)
+                if (device != null) {
+                    fetchAndEmitDeviceState(device, flow)
+                } else {
+                    Log.w(TAG, "Device not found for control: $controlId")
+                }
+            }
+        }
+
+        return flow.asPublisher()
+    }
+
+    override fun performControlAction(controlId: String, action: ControlAction, consumer: Consumer<Int>) {
+        Log.d(TAG, "performControlAction: $controlId, action type: ${action::class.simpleName}")
+
+        val flow = controlFlows[controlId]
+        if (flow == null) {
+            Log.e(TAG, "No flow found for control: $controlId")
+            consumer.accept(ControlAction.RESPONSE_FAIL)
+            return
+        }
+
+        scope.launch {
+            val device = deviceRepository.findDeviceByMacAddress(controlId)
+            if (device == null) {
+                Log.e(TAG, "Device not found: $controlId")
+                consumer.accept(ControlAction.RESPONSE_FAIL)
+                return@launch
+            }
+
+            try {
+                when (action) {
+                    is BooleanAction -> handleToggleAction(device, action.newState, flow, consumer)
+                    is FloatAction -> handleBrightnessAction(device, action.newValue, flow, consumer)
+                    else -> {
+                        Log.w(TAG, "Unknown action type: ${action::class.simpleName}")
+                        consumer.accept(ControlAction.RESPONSE_FAIL)
+                    }
+                }
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Log.e(TAG, "Error performing action on ${device.address}", e)
+                consumer.accept(ControlAction.RESPONSE_FAIL)
+                emitUnavailableControl(device, flow)
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        job.cancel()
+    }
+
+    private suspend fun fetchAndEmitDeviceState(device: Device, flow: MutableSharedFlow<Control>) {
+        try {
+            val api = deviceApiFactory.create(device)
+            val response = api.postJson(JsonPost(verbose = true))
+
+            if (response.isSuccessful) {
+                response.body()?.let { state ->
+                    updateStateAndEmit(device, state, flow)
+                    Log.d(
+                        TAG,
+                        "Emitted state for ${device.address}: on=${state.isOn}, bri=${state.brightness}",
+                    )
+                } ?: run {
+                    Log.w(TAG, "Body is missing for ${device.address}: ${response.code()}")
+                    emitUnavailableControl(device, flow)
+                }
+            } else {
+                Log.w(TAG, "Failed to fetch state for ${device.address}: ${response.code()}")
+                emitUnavailableControl(device, flow)
+            }
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            Log.e(TAG, "Error fetching state for ${device.address}", e)
+            emitUnavailableControl(device, flow)
+        }
+    }
+
+    private suspend fun handleToggleAction(
+        device: Device,
+        newState: Boolean,
+        flow: MutableSharedFlow<Control>,
+        consumer: Consumer<Int>,
+    ) {
+        val api = deviceApiFactory.create(device)
+        val response = api.postJson(JsonPost(isOn = newState, verbose = true))
+
+        if (response.isSuccessful) {
+            response.body()?.let { state ->
+                updateStateAndEmit(device, state, flow)
+                consumer.accept(ControlAction.RESPONSE_OK)
+            } ?: consumer.accept(ControlAction.RESPONSE_FAIL)
+        } else {
+            consumer.accept(ControlAction.RESPONSE_FAIL)
+        }
+    }
+
+    private suspend fun handleBrightnessAction(
+        device: Device,
+        newValue: Float,
+        flow: MutableSharedFlow<Control>,
+        consumer: Consumer<Int>,
+    ) {
+        val brightness = percentToBrightness(newValue)
+        val api = deviceApiFactory.create(device)
+        val response = api.postJson(JsonPost(brightness = brightness, verbose = true))
+
+        if (response.isSuccessful) {
+            response.body()?.let { state ->
+                updateStateAndEmit(device, state, flow)
+                consumer.accept(ControlAction.RESPONSE_OK)
+            } ?: consumer.accept(ControlAction.RESPONSE_FAIL)
+        } else {
+            consumer.accept(ControlAction.RESPONSE_FAIL)
+        }
+    }
+
+    private suspend fun updateStateAndEmit(device: Device, state: State, flow: MutableSharedFlow<Control>) {
+        val currentColor = deviceStates[device.macAddress]?.color
+        val newColor = getColorFromDeviceState(state)
+        // If the new color is the default White (parsing failed/missing), preserve the old color if it exists
+        // Otherwise use the new color (White) or Black as a safe fallback for the control
+        val resolvedColor = if (newColor == Color.WHITE && currentColor != null && currentColor != Color.WHITE) {
+            currentColor
+        } else {
+            newColor.takeIf { it != Color.WHITE } ?: currentColor ?: Color.BLACK
+        }
+
+        val deviceState = DeviceControlState(
+            isOn = state.isOn ?: deviceStates[device.macAddress]?.isOn ?: false,
+            brightness = state.brightness ?: deviceStates[device.macAddress]?.brightness ?: 0,
+            color = resolvedColor,
+        )
+        deviceStates[device.macAddress] = deviceState
+
+        val control = createStatefulControl(device, deviceState, Control.STATUS_OK)
+        flow.emit(control)
+    }
+
+    private suspend fun emitUnavailableControl(device: Device, flow: MutableSharedFlow<Control>) {
+        val cachedState =
+            deviceStates[device.macAddress] ?: DeviceControlState(isOn = false, brightness = 0, color = Color.BLACK)
+        val control = createStatefulControl(device, cachedState, Control.STATUS_DISABLED)
+        flow.emit(control)
+    }
+
+    private fun createStatelessControl(device: Device): Control {
+        val pendingIntent = createPendingIntent(device)
+        val displayName = device.customName.ifBlank { device.originalName.ifBlank { device.address } }
+
+        return Control.StatelessBuilder(device.macAddress, pendingIntent)
+            .setTitle(displayName)
+            .setSubtitle(device.address)
+            .setDeviceType(DeviceTypes.TYPE_LIGHT)
+            .build()
+    }
+
+    private fun createStatefulControl(device: Device, state: DeviceControlState, status: Int): Control {
+        val pendingIntent = createPendingIntent(device)
+        val displayName = device.customName.ifBlank { device.originalName.ifBlank { device.address } }
+        val brightnessPercent = brightnessToPercent(state.brightness)
+
+        val template = ToggleRangeTemplate(
+            device.macAddress,
+            ControlButton(state.isOn, if (state.isOn) "On" else "Off"),
+            /* range = */
+            android.service.controls.templates.RangeTemplate(
+                "${device.macAddress}_range",
+                0f,
+                MAX_BRIGHTNESS_PERCENT,
+                brightnessPercent,
+                BRIGHTNESS_STEP,
+                BRIGHTNESS_FORMAT,
+            ),
+        )
+
+        return Control.StatefulBuilder(device.macAddress, pendingIntent)
+            .setTitle(displayName)
+            .setSubtitle(device.address)
+            .setDeviceType(DeviceTypes.TYPE_LIGHT)
+            .setStatus(status)
+            .setControlTemplate(template)
+            .setCustomColor(ColorStateList.valueOf(state.color))
+            .build()
+    }
+
+    private fun createPendingIntent(device: Device): PendingIntent {
+        // Use wled:// deep link to open the device directly
+        val intent = Intent(Intent.ACTION_VIEW, "wled://${device.macAddress}".toUri())
+            .setClass(this, MainActivity::class.java)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+
+        return PendingIntent.getActivity(
+            this,
+            device.macAddress.hashCode(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    private data class DeviceControlState(val isOn: Boolean, val brightness: Int, val color: Int)
+}

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/util/BrightnessUtils.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/util/BrightnessUtils.kt
@@ -1,0 +1,29 @@
+package ca.cgagnier.wlednativeandroid.util
+
+/**
+ * Maximum brightness value used by WLED (0-255 range)
+ */
+const val MAX_BRIGHTNESS = 255
+
+/**
+ * Maximum brightness percentage (0-100 range)
+ */
+const val MAX_BRIGHTNESS_PERCENT = 100f
+
+/**
+ * Converts WLED brightness (0-255) to percentage (0.0-100.0).
+ *
+ * @param brightness The brightness value from WLED (0-255)
+ * @return The brightness as a percentage (0.0-100.0)
+ */
+fun brightnessToPercent(brightness: Int): Float =
+    (brightness.coerceIn(0, MAX_BRIGHTNESS) / MAX_BRIGHTNESS.toFloat()) * MAX_BRIGHTNESS_PERCENT
+
+/**
+ * Converts percentage (0.0-100.0) to WLED brightness (0-255).
+ *
+ * @param percent The brightness percentage (0.0-100.0)
+ * @return The brightness value for WLED (0-255)
+ */
+fun percentToBrightness(percent: Float): Int =
+    ((percent.coerceIn(0f, MAX_BRIGHTNESS_PERCENT) / MAX_BRIGHTNESS_PERCENT) * MAX_BRIGHTNESS).toInt()

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetUtils.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetUtils.kt
@@ -4,14 +4,11 @@ import android.content.Context
 import android.content.Intent
 import androidx.annotation.ColorInt
 import androidx.core.graphics.ColorUtils
-import ca.cgagnier.wlednativeandroid.ui.MainActivity
+import ca.cgagnier.wlednativeandroid.domain.DeepLinkHandler
 
 @ColorInt
 fun brightenColor(@ColorInt color: Int, factor: Float): Int =
     ColorUtils.blendARGB(color, android.graphics.Color.WHITE, factor)
 
 fun WidgetStateData.toOpenWidgetInAppIntent(context: Context): Intent =
-    Intent(context, MainActivity::class.java).apply {
-        putExtra(MainActivity.EXTRA_DEVICE_MAC_ADDRESS, macAddress)
-        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
-    }
+    DeepLinkHandler.createDeviceIntent(context, macAddress)

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -124,4 +124,8 @@
     <string name="deep_link_error_mac_not_found">Gerät mit MAC-Adresse %1$s nicht in deiner Geräteliste gefunden</string>
     <string name="deep_link_error_unreachable">Konnte Gerät unter %1$s nicht erreichen. Stelle sicher, dass es eingeschaltet und mit dem Netzwerk verbunden ist.</string>
 
+    <!-- Device Controls (Quick Settings) -->
+    <string name="control_on">An</string>
+    <string name="control_off">Aus</string>
+
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -122,4 +122,9 @@
     <string name="deep_link_error_title">Appareil introuvable</string>
     <string name="deep_link_error_mac_not_found">L\'appareil avec l\'adresse MAC %1$s n\'a pas été trouvé dans votre liste</string>
     <string name="deep_link_error_unreachable">Impossible de joindre l\'appareil à %1$s. Assurez-vous qu\'il est allumé et connecté au réseau.</string>
+
+    <!-- Device Controls (Quick Settings) -->
+    <string name="control_on">Allumé</string>
+    <string name="control_off">Éteint</string>
+
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -120,4 +120,9 @@
     <string name="deep_link_error_title">未找到设备</string>
     <string name="deep_link_error_mac_not_found">未在列表中找到 MAC 地址为 %1$s 的设备</string>
     <string name="deep_link_error_unreachable">无法连接到 %1$s。请确保设备已开机并连接到网络。</string>
+
+    <!-- Device Controls (Quick Settings) -->
+    <string name="control_on">开</string>
+    <string name="control_off">关</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,4 +125,8 @@
     <string name="deep_link_error_mac_not_found">Device with MAC address %1$s not found in your device list</string>
     <string name="deep_link_error_unreachable">Could not reach device at %1$s. Make sure it is powered on and connected to the network.</string>
 
+    <!-- Device Controls (Quick Settings) -->
+    <string name="control_on">On</string>
+    <string name="control_off">Off</string>
+
 </resources>

--- a/app/src/test/java/ca/cgagnier/wlednativeandroid/util/BrightnessUtilsTest.kt
+++ b/app/src/test/java/ca/cgagnier/wlednativeandroid/util/BrightnessUtilsTest.kt
@@ -1,0 +1,95 @@
+package ca.cgagnier.wlednativeandroid.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BrightnessUtilsTest {
+
+    // --- brightnessToPercent tests ---
+
+    @Test
+    fun `brightnessToPercent with 0 returns 0 percent`() {
+        assertEquals(0f, brightnessToPercent(0), 0.01f)
+    }
+
+    @Test
+    fun `brightnessToPercent with 255 returns 100 percent`() {
+        assertEquals(100f, brightnessToPercent(255), 0.01f)
+    }
+
+    @Test
+    fun `brightnessToPercent with 128 returns approximately 50 percent`() {
+        // 128/255 * 100 ≈ 50.2%
+        assertEquals(50.2f, brightnessToPercent(128), 0.1f)
+    }
+
+    @Test
+    fun `brightnessToPercent with 1 returns approximately 0_4 percent`() {
+        // 1/255 * 100 ≈ 0.39%
+        assertEquals(0.39f, brightnessToPercent(1), 0.1f)
+    }
+
+    @Test
+    fun `brightnessToPercent clamps negative values to 0`() {
+        assertEquals(0f, brightnessToPercent(-10), 0.01f)
+    }
+
+    @Test
+    fun `brightnessToPercent clamps values above 255 to 100`() {
+        assertEquals(100f, brightnessToPercent(300), 0.01f)
+    }
+
+    // --- percentToBrightness tests ---
+
+    @Test
+    fun `percentToBrightness with 0 percent returns 0`() {
+        assertEquals(0, percentToBrightness(0f))
+    }
+
+    @Test
+    fun `percentToBrightness with 100 percent returns 255`() {
+        assertEquals(255, percentToBrightness(100f))
+    }
+
+    @Test
+    fun `percentToBrightness with 50 percent returns 127`() {
+        // 50/100 * 255 = 127.5 → 127
+        assertEquals(127, percentToBrightness(50f))
+    }
+
+    @Test
+    fun `percentToBrightness with 1 percent returns 2`() {
+        // 1/100 * 255 = 2.55 → 2
+        assertEquals(2, percentToBrightness(1f))
+    }
+
+    @Test
+    fun `percentToBrightness clamps negative values to 0`() {
+        assertEquals(0, percentToBrightness(-10f))
+    }
+
+    @Test
+    fun `percentToBrightness clamps values above 100 to 255`() {
+        assertEquals(255, percentToBrightness(150f))
+    }
+
+    // --- Roundtrip tests ---
+
+    @Test
+    fun `roundtrip from brightness to percent and back preserves approximate value`() {
+        val original = 200
+        val percent = brightnessToPercent(original)
+        val roundtrip = percentToBrightness(percent)
+        // Allow for rounding differences
+        assertEquals(original.toFloat(), roundtrip.toFloat(), 1f)
+    }
+
+    @Test
+    fun `roundtrip from percent to brightness and back preserves approximate value`() {
+        val original = 75f
+        val brightness = percentToBrightness(original)
+        val roundtrip = brightnessToPercent(brightness)
+        // Allow for rounding differences
+        assertEquals(original, roundtrip, 1f)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ hiltNavigationCompose = "1.3.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 kotlin = "2.3.0"
+kotlinxCoroutinesJdk9 = "1.10.2"
 kotlinxSerializationJson = "1.9.0"
 ksp = "2.3.4"
 lifecycleViewmodelKtx = "2.10.0"
@@ -84,6 +85,7 @@ hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hiltA
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hiltCompiler" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+kotlinx-coroutines-jdk9 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk9", version.ref = "kotlinxCoroutinesJdk9" }
 lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycleViewmodelKtx" }
 logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "loggingInterceptor" }
 material-kolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }


### PR DESCRIPTION
This commit introduces support for Android 11's Device Controls, allowing users to manage their WLED devices directly from the power menu or quick settings.

- Adds `WledControlsService` to handle device discovery, state updates, and actions (on/off, brightness).
- Implements `ControlsProviderService` to publish device controls to the Android system.
- Adds `BrightnessUtils.kt` with helper functions to convert between the WLED 0-255 scale and a 0-100 percentage.
- Includes unit tests for the brightness conversion logic.
- Adds the `kotlinx-coroutines-jdk9` dependency to bridge Coroutine Flows with Java's `Flow.Publisher`.
- Updates the `AndroidManifest.xml` to declare the new service.

This was originally made by @pacjo in #41, but I was too slow to merge it and it diverged too much. Thank you @pacjo for the help!