### PR TITLE
Fix: Use FLAG_MUTABLE for notification PendingIntent

### DIFF
--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/domain/DeepLinkHandler.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/domain/DeepLinkHandler.kt
@@ -48,6 +48,7 @@ class DeepLinkHandler @Inject constructor() {
         fun createDeviceIntent(context: Context, macAddress: String): Intent =
             Intent(Intent.ACTION_VIEW, "$SCHEME_WLED://$macAddress".toUri())
                 .setClass(context, MainActivity::class.java)
+                .setPackage(context.packageName)
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
     }
 

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/service/controls/WledControlsService.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/service/controls/WledControlsService.kt
@@ -331,7 +331,7 @@ class WledControlsService : ControlsProviderService() {
             this,
             getOrCreateRequestCode(device.macAddress),
             intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
         )
     }
 


### PR DESCRIPTION
Updated the `PendingIntent` flag from `FLAG_IMMUTABLE` to `FLAG_MUTABLE` to resolve a crash when opening the device by long pressing the Device Control in the Quick access system menu.