### PR TITLE
Change style of power button for `off` devices and refactor

### DIFF
--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetContent.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetContent.kt
@@ -121,7 +121,7 @@ private fun DeviceWidgetContentWide(data: WidgetStateData) {
                     showAddress = true,
                 )
                 // Switch stays next to content in Wide mode
-                PowerButton(data)
+                PowerButton(isOn = data.isOn)
             }
             // TODO: Add a way for users to configure quick actions
             if (data.quickActionsEnabled) {
@@ -146,7 +146,7 @@ private fun DeviceWidgetContentNarrow(data: WidgetStateData) {
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            PowerButton(data)
+            PowerButton(isOn = data.isOn)
             DeviceDetailsColumn(
                 data = data,
                 modifier = GlanceModifier.defaultWeight(),

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/components/PowerButton.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/components/PowerButton.kt
@@ -98,7 +98,6 @@ private fun PowerButtonOnState() {
 
 @Composable
 private fun PowerButtonOffState() {
-    val buttonColor = GlanceTheme.colors.surfaceVariant
     val onButtonColor = GlanceTheme.colors.onSurfaceVariant
 
     // OFF State: Simple icon, no background, no outline, no glow

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/components/PowerButton.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/components/PowerButton.kt
@@ -16,19 +16,21 @@ import androidx.glance.appwidget.action.actionRunCallback
 import androidx.glance.appwidget.cornerRadius
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
+import androidx.glance.layout.Row
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.size
+import androidx.glance.preview.ExperimentalGlancePreviewApi
+import androidx.glance.preview.Preview
 import androidx.glance.unit.ColorProvider
 import ca.cgagnier.wlednativeandroid.R
 import ca.cgagnier.wlednativeandroid.widget.TogglePowerAction
-import ca.cgagnier.wlednativeandroid.widget.WidgetStateData
 import ca.cgagnier.wlednativeandroid.widget.brightenColor
 
 private const val GLOW_BRIGHTNESS_FACTOR = 0.9f
 private const val OUTLINE_BRIGHTNESS_FACTOR = 0.9f
 
 @Composable
-fun PowerButton(data: WidgetStateData) {
+fun PowerButton(isOn: Boolean) {
     Box(
         modifier = GlanceModifier
             .size(48.dp) // Total size including glow
@@ -36,16 +38,15 @@ fun PowerButton(data: WidgetStateData) {
             .clickable(
                 actionRunCallback<TogglePowerAction>(
                     actionParametersOf(
-                        TogglePowerAction.keyIsOn to data.isOn,
+                        TogglePowerAction.keyIsOn to isOn,
                     ),
                 ),
             ),
         contentAlignment = Alignment.Center,
     ) {
-        if (data.isOn) {
-            PowerButtonOnState()
-        } else {
-            PowerButtonOffState()
+        when (isOn) {
+            true -> PowerButtonOnState()
+            false -> PowerButtonOffState()
         }
     }
 }
@@ -100,17 +101,24 @@ private fun PowerButtonOffState() {
     val buttonColor = GlanceTheme.colors.surfaceVariant
     val onButtonColor = GlanceTheme.colors.onSurfaceVariant
 
-    // OFF State: Simple solid surfaceVariant, no outline, no glow
-    Image(
-        provider = ImageProvider(R.drawable.widget_circle_fill),
-        contentDescription = null,
-        modifier = GlanceModifier.size(32.dp),
-        colorFilter = ColorFilter.tint(buttonColor),
-    )
+    // OFF State: Simple icon, no background, no outline, no glow
     Image(
         provider = ImageProvider(R.drawable.outline_power_settings_new_24),
         contentDescription = "Toggle Power",
         modifier = GlanceModifier.size(20.dp),
         colorFilter = ColorFilter.tint(onButtonColor),
     )
+}
+
+@Suppress("MagicNumber")
+@OptIn(ExperimentalGlancePreviewApi::class)
+@Preview(widthDp = 120, heightDp = 70)
+@Composable
+private fun WidgetPowerButtonPreview() {
+    GlanceTheme {
+        Row {
+            PowerButton(isOn = true)
+            PowerButton(isOn = false)
+        }
+    }
 }


### PR DESCRIPTION
- Changed the implementation of the "off" state to display only an icon without a background circle.
- Updated the `PowerButton` composable to accept a simple `isOn: Boolean` parameter instead of the full `WidgetStateData` object.
- Added a `@Preview` for the `PowerButton` to display both on and off states.