### PR TITLE
refactor(widget): Centralize device name logic and improve widget upd…

### DIFF
--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/service/websocket/WebsocketClient.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/service/websocket/WebsocketClient.kt
@@ -80,7 +80,7 @@ class WebsocketClient(
                     // Ideally, this should probably not be done in the client directly
                     coroutineScope.launch {
                         saveDeviceIfChanged(deviceStateInfo)
-                        updateWidgets(deviceStateInfo)
+                        updateWidgets()
                     }
                 } else {
                     Log.w(TAG, "Received a null message after parsing.")
@@ -144,12 +144,10 @@ class WebsocketClient(
     /**
      * Updates any active widgets for this device with the latest state.
      */
-    private suspend fun updateWidgets(deviceStateInfo: DeviceStateInfo) {
-        widgetManager.updateWidgetsFromDeviceState(
+    private suspend fun updateWidgets() {
+        widgetManager.updateWidgetsFromDeviceWithState(
             applicationContext,
-            deviceState.device.macAddress,
-            deviceState.device.address,
-            deviceStateInfo,
+            deviceState,
         )
     }
 

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/deviceEdit/DeviceEditViewModel.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/deviceEdit/DeviceEditViewModel.kt
@@ -1,5 +1,6 @@
 package ca.cgagnier.wlednativeandroid.ui.homeScreen.deviceEdit
 
+import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -10,7 +11,9 @@ import ca.cgagnier.wlednativeandroid.repository.DeviceRepository
 import ca.cgagnier.wlednativeandroid.repository.VersionWithAssetsRepository
 import ca.cgagnier.wlednativeandroid.service.api.github.GithubApi
 import ca.cgagnier.wlednativeandroid.service.update.ReleaseService
+import ca.cgagnier.wlednativeandroid.widget.WledWidgetManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -24,6 +27,8 @@ class DeviceEditViewModel @Inject constructor(
     private val repository: DeviceRepository,
     private val versionWithAssetsRepository: VersionWithAssetsRepository,
     private val githubApi: GithubApi,
+    private val widgetManager: WledWidgetManager,
+    @param:ApplicationContext private val applicationContext: Context,
 ) : ViewModel() {
 
     private var _updateDetailsVersion: MutableStateFlow<VersionWithAssets?> = MutableStateFlow(null)
@@ -40,14 +45,16 @@ class DeviceEditViewModel @Inject constructor(
     val isCheckingUpdates = _isCheckingUpdates.asStateFlow()
 
     fun updateCustomName(device: Device, name: String) = viewModelScope.launch(Dispatchers.IO) {
-        val isCustomName = name != ""
         val updatedDevice = device.copy(
             customName = name,
         )
 
-        Log.d(TAG, "updateCustomName: $name, isCustom: $isCustomName")
+        Log.d(TAG, "updateCustomName: $name")
 
         repository.update(updatedDevice)
+
+        // Update widgets to show the new name
+        widgetManager.updateWidgetNamesForDevice(applicationContext, updatedDevice)
     }
 
     fun updateDeviceHidden(device: Device, isHidden: Boolean) = viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/list/DeviceWebsocketListViewModel.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/list/DeviceWebsocketListViewModel.kt
@@ -200,7 +200,7 @@ class DeviceWebsocketListViewModel @Inject constructor(
     }
 
     fun deleteDevice(device: Device) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             Log.d(TAG, "Deleting device ${device.originalName} - ${device.address}")
             widgetManager.deleteWidgetsForDevice(applicationContext, device.macAddress)
             deviceRepository.delete(device)

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/list/DeviceWebsocketListViewModel.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/list/DeviceWebsocketListViewModel.kt
@@ -1,5 +1,6 @@
 package ca.cgagnier.wlednativeandroid.ui.homeScreen.list
 
+import android.content.Context
 import android.util.Log
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -13,7 +14,9 @@ import ca.cgagnier.wlednativeandroid.repository.UserPreferencesRepository
 import ca.cgagnier.wlednativeandroid.service.websocket.DeviceWithState
 import ca.cgagnier.wlednativeandroid.service.websocket.WebsocketClient
 import ca.cgagnier.wlednativeandroid.service.websocket.WebsocketClientFactory
+import ca.cgagnier.wlednativeandroid.widget.WledWidgetManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -32,6 +35,8 @@ class DeviceWebsocketListViewModel @Inject constructor(
     userPreferencesRepository: UserPreferencesRepository,
     private val deviceRepository: DeviceRepository,
     private val websocketClientFactory: WebsocketClientFactory,
+    private val widgetManager: WledWidgetManager,
+    @ApplicationContext private val applicationContext: Context,
 ) : ViewModel(),
     DefaultLifecycleObserver {
     private val activeClients = MutableStateFlow<Map<String, WebsocketClient>>(emptyMap())
@@ -197,6 +202,7 @@ class DeviceWebsocketListViewModel @Inject constructor(
     fun deleteDevice(device: Device) {
         viewModelScope.launch {
             Log.d(TAG, "Deleting device ${device.originalName} - ${device.address}")
+            widgetManager.deleteWidgetsForDevice(applicationContext, device.macAddress)
             deviceRepository.delete(device)
         }
     }

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WledWidgetConfigureActivity.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WledWidgetConfigureActivity.kt
@@ -32,6 +32,7 @@ import ca.cgagnier.wlednativeandroid.model.Device
 import ca.cgagnier.wlednativeandroid.repository.DeviceRepository
 import ca.cgagnier.wlednativeandroid.ui.components.deviceName
 import ca.cgagnier.wlednativeandroid.ui.theme.WLEDNativeTheme
+import ca.cgagnier.wlednativeandroid.widget.components.getDeviceName
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -87,7 +88,7 @@ class WledWidgetConfigureActivity : ComponentActivity() {
             val widgetData = WidgetStateData(
                 macAddress = device.macAddress,
                 address = device.address,
-                name = device.customName.ifBlank { device.originalName },
+                name = getDeviceName(device, getString(R.string.default_device_name)),
                 isOn = false,
                 lastUpdated = System.currentTimeMillis(),
             )

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/components/GetDeviceName.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/components/GetDeviceName.kt
@@ -1,0 +1,17 @@
+package ca.cgagnier.wlednativeandroid.widget.components
+
+import ca.cgagnier.wlednativeandroid.model.Device
+
+/**
+ * Returns the display name for a device following the hierarchy:
+ * 1. Custom name (if not blank)
+ * 2. Original name (if not blank)
+ * 3. Fallback name
+ *
+ * This is a non-Composable version of the [ca.cgagnier.wlednativeandroid.ui.components.deviceName]
+ * function that can be used outside of Compose context (e.g., in background services).
+ */
+fun getDeviceName(device: Device?, fallbackName: String): String =
+    device?.customName?.trim().takeIf { !it.isNullOrBlank() }
+        ?: device?.originalName?.trim().takeIf { !it.isNullOrBlank() }
+        ?: fallbackName


### PR DESCRIPTION
…ates

This commit introduces a centralized function for determining a device's display name and refactors widget updates to be more robust and efficient.

- A non-composable `getDeviceName` utility function has been created to provide a consistent device name (custom name, then original name, then a fallback) for use in widgets and other non-UI contexts.
- The `WledWidgetConfigureActivity` now uses this new function when creating initial widget data.
- Device name changes now trigger an immediate update on associated widgets, ensuring the new name is reflected without waiting for the next state refresh.
- Deleting a device now correctly clears the data for all its associated widgets, putting them into a re-configurable error state.
- WebSocket and API update logic in `WledWidgetManager` has been streamlined, now passing the full `DeviceWithState` or `Device` object instead of multiple parameters. This allows the manager to consistently use the new `getDeviceName` function for all updates.