### PR TITLE
fix: update widget when device IP address changes

### DIFF
--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/service/DeviceFirstContactService.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/service/DeviceFirstContactService.kt
@@ -1,5 +1,6 @@
 package ca.cgagnier.wlednativeandroid.service
 
+import android.content.Context
 import android.util.Log
 import ca.cgagnier.wlednativeandroid.model.Device
 import ca.cgagnier.wlednativeandroid.model.wledapi.Info
@@ -9,6 +10,8 @@ import ca.cgagnier.wlednativeandroid.repository.getOrCreateRepositoryId
 import ca.cgagnier.wlednativeandroid.service.api.DeviceApiFactory
 import ca.cgagnier.wlednativeandroid.service.update.getRepositoryFromInfo
 import ca.cgagnier.wlednativeandroid.util.isIpAddress
+import ca.cgagnier.wlednativeandroid.widget.WledWidgetManager
+import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
 import javax.inject.Inject
 
@@ -21,6 +24,8 @@ class DeviceFirstContactService @Inject constructor(
     private val repositoryDao: RepositoryDao,
     private val repository: DeviceRepository,
     private val deviceApiFactory: DeviceApiFactory,
+    private val widgetManager: WledWidgetManager,
+    @param:ApplicationContext private val applicationContext: Context,
 ) {
     /**
      * Creates a new device record in the database.
@@ -74,6 +79,7 @@ class DeviceFirstContactService @Inject constructor(
             )
         }
         repository.update(updatedDevice)
+        widgetManager.updateWidgetDeviceDetails(applicationContext, updatedDevice)
         return updatedDevice
     }
 

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/deviceEdit/DeviceEditViewModel.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/deviceEdit/DeviceEditViewModel.kt
@@ -59,7 +59,7 @@ class DeviceEditViewModel @Inject constructor(
         deviceRepository.update(updatedDevice)
 
         // Update widgets to show the new name
-        widgetManager.updateWidgetNamesForDevice(applicationContext, updatedDevice)
+        widgetManager.updateWidgetDeviceDetails(applicationContext, updatedDevice)
     }
 
     fun updateDeviceHidden(device: Device, isHidden: Boolean) = viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WledWidgetManager.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WledWidgetManager.kt
@@ -136,10 +136,10 @@ class WledWidgetManager @Inject constructor(
     }
 
     /**
-     * Updates the name displayed on all widgets for a device.
-     * Call this when the device's customName or originalName changes.
+     * Updates the name and address displayed on all widgets for a device.
+     * Call this when the device's customName, originalName or address changes.
      */
-    suspend fun updateWidgetNamesForDevice(context: Context, device: Device) {
+    suspend fun updateWidgetDeviceDetails(context: Context, device: Device) {
         val manager = GlanceAppWidgetManager(context)
         val glanceIds = manager.getGlanceIds(WledWidget::class.java)
         val displayName = getDeviceName(device, context.getString(R.string.default_device_name))
@@ -147,8 +147,8 @@ class WledWidgetManager @Inject constructor(
         glanceIds.forEach { glanceId ->
             val widgetState = getWidgetState(context, glanceId) ?: return@forEach
             if (widgetState.macAddress == device.macAddress) {
-                Log.d(TAG, "Updating widget name for MAC ${device.macAddress} to $displayName")
-                val newData = widgetState.copy(name = displayName)
+                Log.d(TAG, "Updating widget details for MAC ${device.macAddress} to $displayName at ${device.address}")
+                val newData = widgetState.copy(name = displayName, address = device.address)
                 saveStateAndPush(context, glanceId, newData)
             }
         }


### PR DESCRIPTION
### Description
Fixes an issue where home screen widgets would get stuck with a previous IP address when a WLED device's IP changed. The app can already recognize and update the address associated with a device (e.g. via mDNS discovery), and now home screen widgets will be updated the same way.

### Changes
- **WledWidgetManager**: Renamed `updateWidgetNamesForDevice` to updateWidgetDeviceDetails and updated it to sync the `address` property in WidgetStateData.
- **DeviceFirstContactService**: Injected WledWidgetManager to trigger an update of the widget device details whenever the device's IP address is updated after mDNS discovery.
- **DeviceEditViewModel**: Updated caller to use the newly named method `updateWidgetDeviceDetails`.

This will fix #127