### PR TITLE
build: Enforce complete translations in CI checks

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,6 +75,9 @@ android {
         enableAggregatingTask = true
     }
     namespace = "ca.cgagnier.wlednativeandroid"
+    lint {
+        fatal += "MissingTranslation"
+    }
 }
 
 ksp {


### PR DESCRIPTION
## Description
This Pull Request modifies the project's build configuration to enforce complete internationalization coverage on all pull requests.

By marking the Android Lint rule `MissingTranslation` as a `fatal` error, any PR that adds a new string resource but fails to provide equivalent translations for all supported languages will now cause the existing GitHub Actions check to fail. This directly addresses the goal of notifying users when they need to provide all language translations.

## Changes
- `app/build.gradle.kts`: Added `lint { fatal += "MissingTranslation" }` to the `android` block.

## Testing
- Verified locally that running `./gradlew lintDebug` on a codebase with a missing translation properly fails the build with a descriptive error.
- Verified unit tests still pass successfully.

---
*PR created automatically by Jules for task [6991151126945993938](https://jules.google.com/task/6991151126945993938) started by @Moustachauve*