### PR TITLE
feat: improve update source display on device edit screen

### DIFF
--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/deviceEdit/DeviceEdit.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/deviceEdit/DeviceEdit.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -47,6 +48,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -79,6 +81,11 @@ fun DeviceEdit(
     val updateDisclaimerVersion by viewModel.updateDisclaimerVersion.collectAsState()
     val updateInstallVersion by viewModel.updateInstallVersion.collectAsState()
     val isCheckingUpdates by viewModel.isCheckingUpdates.collectAsState()
+    val repository by viewModel.repository.collectAsState()
+
+    LaunchedEffect(device.device.repositoryId) {
+        viewModel.loadRepository(device.device.repositoryId)
+    }
 
     Scaffold(
         topBar = {
@@ -181,6 +188,31 @@ fun DeviceEdit(
                                     viewModel.checkForUpdates(device.device)
                                 },
                             )
+                        }
+                        repository?.let { repo ->
+                            HorizontalDivider(
+                                modifier = Modifier.padding(top = 10.dp, bottom = 6.dp),
+                                color = MaterialTheme.colorScheme.outlineVariant,
+                            )
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.update_source),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.weight(1f),
+                                )
+                                Text(
+                                    text = repo.ownerAndRepo,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    textAlign = TextAlign.End,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/deviceEdit/DeviceEdit.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/deviceEdit/DeviceEdit.kt
@@ -202,12 +202,13 @@ fun DeviceEdit(
                                     text = stringResource(R.string.update_source),
                                     style = MaterialTheme.typography.labelSmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    modifier = Modifier.weight(1f),
+                                    modifier = Modifier.padding(end = 8.dp),
                                 )
                                 Text(
                                     text = repo.ownerAndRepo,
                                     style = MaterialTheme.typography.labelSmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.weight(1f),
                                     textAlign = TextAlign.End,
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/deviceEdit/DeviceEditViewModel.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/deviceEdit/DeviceEditViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import ca.cgagnier.wlednativeandroid.model.Branch
 import ca.cgagnier.wlednativeandroid.model.Device
+import ca.cgagnier.wlednativeandroid.model.Repository
 import ca.cgagnier.wlednativeandroid.model.VersionWithAssets
 import ca.cgagnier.wlednativeandroid.repository.DeviceRepository
 import ca.cgagnier.wlednativeandroid.repository.RepositoryDao
@@ -48,6 +49,13 @@ class DeviceEditViewModel @Inject constructor(
 
     private var _isCheckingUpdates = MutableStateFlow(false)
     val isCheckingUpdates = _isCheckingUpdates.asStateFlow()
+
+    private val _repository = MutableStateFlow<Repository?>(null)
+    val repository = _repository.asStateFlow()
+
+    fun loadRepository(repositoryId: Long) = viewModelScope.launch(Dispatchers.IO) {
+        _repository.value = repositoryDao.getRepositoryById(repositoryId)
+    }
 
     fun updateCustomName(device: Device, name: String) = viewModelScope.launch(Dispatchers.IO) {
         val updatedDevice = device.copy(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -85,6 +85,7 @@
     <string name="unknown_error">Unbekannter Fehler</string>
     <string name="success">Erfolg!</string>
     <string name="update_channel">Update-Kanal</string>
+    <string name="update_source">Update-Quelle</string>
     <string name="stable">Stable</string>
     <string name="beta">Beta</string>
     <string name="your_device_is_up_to_date">Dein Gerät ist auf dem neuesten Stand</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -84,6 +84,7 @@
     <string name="unknown_error">Erreur inconnue</string>
     <string name="success">Succès!</string>
     <string name="update_channel">Variante de MàJ</string>
+    <string name="update_source">Source de mise à jour</string>
     <string name="stable">Stable</string>
     <string name="beta">Bêta</string>
     <string name="version_v_num">Version <xliff:g example="v0.14.0" id="version_name">%1$s</xliff:g></string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -82,6 +82,7 @@
     <string name="unknown_error">未知错误</string>
     <string name="success">成功！</string>
     <string name="update_channel">更新频道</string>
+    <string name="update_source">更新来源</string>
     <string name="stable">稳定</string>
     <string name="beta">Beta</string>
     <string name="your_device_is_up_to_date">您的设备已是最新版本</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,6 +86,7 @@
     <string name="unknown_error">Unknown Error</string>
     <string name="success">Success!</string>
     <string name="update_channel">Update Channel</string>
+    <string name="update_source">Update Source</string>
     <string name="stable">Stable</string>
     <string name="beta">Beta</string>
     <string name="your_device_is_up_to_date">Your device is up to date</string>


### PR DESCRIPTION
### Summary
This PR adds the firmware update source information to the Device Edit screen, allowing users to see which repository is being tracked for updates. 

### Changes
*   **Added Update Source Display:** Users can now see the name of the repository (e.g., `wled/WLED` or `MoonModules/WLED-MM`) being used for firmware updates.
*   **Integrated UI Design:** The update source is displayed within the update status card at the bottom, providing a more cohesive overview of the device's software state.
*   **Styling:** Used subtle typography (`labelSmall`) and colors to keep the primary focus on the "Check for Updates" actions while still providing the necessary context.
*   **Multi-language Support:** Added localized strings for the "Update Source" label in all supported languages (English, French, Chinese, and German).

### Technical Implementation
*   Updated `DeviceEditViewModel` to fetch the `Repository` object from the database using the device's `repositoryId`.
*   Integrated the display into the `DeviceEdit` composable, ensuring the repository information is reactive and loads correctly when the screen opens.

