### PR TITLE
Update release-drafter templates to use RESOLVED_VERSION

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: 'v$NEXT_PATCH_VERSION'
-tag-template: 'v$NEXT_PATCH_VERSION'
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
 categories:
   - title: '🚀 New Features'
     labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -21,10 +21,13 @@ version-resolver:
   minor:
     labels:
       - 'minor'
+      - 'feature'
+      - 'enhancement'
   patch:
     labels:
       - 'patch'
       - 'fix'
+      - 'bug'
   default: patch
 autolabeler:
   - label: "documentation"
@@ -55,10 +58,13 @@ autolabeler:
       - '/fix\/.+/'
       - '/bug(\/|-).+/'
     title:
-      - "/fix/i"
+      - '/fix/i'
       - '/^bug?:/i'
   - label: "feature"
     branch:
+      - '/feat(ure)?(\/|-).+/'
+      - '/enhancement(\/|-).+/'
+    title:
       - '/^feat(ure)?:/i'
       - '/^enhancement?:/i'
 template: |


### PR DESCRIPTION
* Change `name-template` and `tag-template` from `v$NEXT_PATCH_VERSION` to `v$RESOLVED_VERSION` to allow for more flexible versioning and more "automatic" versioning based on CL labels.