### PR TITLE
fix(ui): improve DeviceEdit experience for offline devices without state

### DIFF
--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/deviceEdit/DeviceEdit.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/homeScreen/deviceEdit/DeviceEdit.kt
@@ -319,6 +319,8 @@ private fun UpdateStatusCard(
     onCheckForUpdates: () -> Unit,
     onSeeUpdateDetails: (String) -> Unit,
 ) {
+    val isOfflineNoState = !device.isOnline && device.stateInfo.value == null
+
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -329,19 +331,23 @@ private fun UpdateStatusCard(
                 .padding(12.dp)
                 .fillMaxWidth(),
         ) {
-            val currentUpdateTag = uiState.updateTag
-            if (currentUpdateTag != null) {
-                UpdateAvailable(
-                    device = device,
-                    updateTag = currentUpdateTag,
-                    seeUpdateDetails = { onSeeUpdateDetails(currentUpdateTag) },
-                )
+            if (isOfflineNoState) {
+                DeviceOfflineStatus()
             } else {
-                NoUpdateAvailable(
-                    device = device,
-                    isCheckingUpdates = uiState.isCheckingUpdates,
-                    checkForUpdate = onCheckForUpdates,
-                )
+                val currentUpdateTag = uiState.updateTag
+                if (currentUpdateTag != null) {
+                    UpdateAvailable(
+                        device = device,
+                        updateTag = currentUpdateTag,
+                        seeUpdateDetails = { onSeeUpdateDetails(currentUpdateTag) },
+                    )
+                } else {
+                    NoUpdateAvailable(
+                        device = device,
+                        isCheckingUpdates = uiState.isCheckingUpdates,
+                        checkForUpdate = onCheckForUpdates,
+                    )
+                }
             }
             uiState.repository?.let { repo ->
                 HorizontalDivider(
@@ -369,6 +375,32 @@ private fun UpdateStatusCard(
                     )
                 }
             }
+        }
+    }
+}
+
+/** Shows an informational message when the device is offline and has no known state. */
+@Composable
+private fun DeviceOfflineStatus() {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            modifier = Modifier
+                .padding(8.dp)
+                .padding(end = 10.dp),
+            painter = painterResource(R.drawable.outline_wifi_off_24),
+            contentDescription = stringResource(R.string.is_offline),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Column {
+            Text(
+                stringResource(R.string.device_offline_update_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                stringResource(R.string.device_offline_update_message),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }
@@ -588,6 +620,28 @@ private fun PreviewBetaNoBack() {
             ),
             actions = DeviceEditActions(),
             canNavigateBack = false,
+            navigateUp = {},
+        )
+    }
+}
+
+@Preview(name = "Offline — no state", showBackground = true)
+@Composable
+private fun PreviewOfflineNoState() {
+    WLEDNativeTheme(darkTheme = false) {
+        DeviceEditContent(
+            device = DeviceWithState(
+                Device(
+                    macAddress = AP_MODE_MAC_ADDRESS,
+                    address = "192.168.1.42",
+                    originalName = "Garage LEDs",
+                ),
+            ),
+            uiState = DeviceEditUiState(
+                repository = Repository.BUILT_IN_REPOSITORIES.first(),
+            ),
+            actions = DeviceEditActions(),
+            canNavigateBack = true,
             navigateUp = {},
         )
     }

--- a/app/src/main/res/drawable/outline_wifi_off_24.xml
+++ b/app/src/main/res/drawable/outline_wifi_off_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M21,11l2,-2c-3.73,-3.73 -8.87,-5.15 -13.7,-4.31l2.58,2.58c3.3,-0.02 6.61,1.22 9.12,3.73zM19,13c-1.08,-1.08 -2.36,-1.85 -3.72,-2.33l3.02,3.02 0.7,-0.69zM9,17l3,3 3,-3c-1.65,-1.66 -4.34,-1.66 -6,0zM3.41,1.64 2,3.05 5.05,6.1C3.59,6.83 2.22,7.79 1,9l2,2c1.23,-1.23 2.65,-2.16 4.17,-2.78l2.24,2.24C7.79,10.89 6.27,11.74 5,13l2,2c1.35,-1.35 3.11,-2.04 4.89,-2.06l7.08,7.08 1.41,-1.41L3.41,1.64z"/>
+</vector>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -90,6 +90,8 @@
     <string name="beta">Beta</string>
     <string name="your_device_is_up_to_date">Dein Gerät ist auf dem neuesten Stand</string>
     <string name="version_v_num">Version <xliff:g example="v0.14.0" id="version_name">%1$s</xliff:g></string>
+    <string name="device_offline_update_title">Updates können nicht geprüft werden</string>
+    <string name="device_offline_update_message">Das Gerät muss online sein, um die aktuelle Version zu verifizieren und nach verfügbaren Updates zu suchen.</string>
     <string name="select_a_device_from_the_list">Wähle ein Gerät aus der Liste</string>
     <string name="downloading_file">Lade %1$s herunter…</string>
     <string name="help">WLED Hilfe</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -89,6 +89,8 @@
     <string name="beta">Bêta</string>
     <string name="version_v_num">Version <xliff:g example="v0.14.0" id="version_name">%1$s</xliff:g></string>
     <string name="your_device_is_up_to_date">Votre appareil est à jour</string>
+    <string name="device_offline_update_title">Impossible de vérifier les mises à jour</string>
+    <string name="device_offline_update_message">L\'appareil doit être en ligne pour vérifier sa version actuelle et chercher des mises à jour disponibles.</string>
     <string name="select_a_device_from_the_list">Veuillez choisir un appareil</string>
     <string name="downloading_file">Téléchargement de %1$s…</string>
     <string name="help">WLED Aide</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -86,6 +86,8 @@
     <string name="stable">稳定</string>
     <string name="beta">Beta</string>
     <string name="your_device_is_up_to_date">您的设备已是最新版本</string>
+    <string name="device_offline_update_title">无法检查更新</string>
+    <string name="device_offline_update_message">设备必须在线才能验证其当前版本并检查可用更新。</string>
     <string name="version_v_num">版本 <xliff:g example="v0.14.0" id="version_name">%1$s</xliff:g></string>
     <string name="select_a_device_from_the_list">从列表中选择一个设备</string>
     <string name="downloading_file">正在下载 %1$s…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,6 +91,8 @@
     <string name="beta">Beta</string>
     <string name="your_device_is_up_to_date">Your device is up to date</string>
     <string name="version_v_num">Version <xliff:g example="v0.14.0" id="version_name">%1$s</xliff:g></string>
+    <string name="device_offline_update_title">Unable to check for updates</string>
+    <string name="device_offline_update_message">The device must be online to verify its current version and check for available updates.</string>
     <string name="select_a_device_from_the_list">Select a device from the list</string>
     <string name="help">WLED Help</string>
     <string name="support_me">Support Moustachauve</string>


### PR DESCRIPTION
This PR improves the user experience on the `DeviceEdit` page when a device is offline and has no state in memory (e.g., when the app was just launched or a new device was added). 

Previously, the UI would misleadingly show "Your device is up to date" with "Version <?>" and a "Check for update" button that would fail.

### Key Changes:
- **New Offline State UI**: Added a `DeviceOfflineStatus` component that explicitly states the device must be online to check for updates.
- **Improved Logic**: `UpdateStatusCard` now detects the "Offline + No State" condition and displays the appropriate informational message.
- **New Vector Asset**: Added `outline_wifi_off_24.xml` for better visual indication of the offline status.
- **Localization**: Added and translated strings in English, French, and Chinese.
- **Compose Preview**: Added a `PreviewOfflineNoState` to verify the UI without a running device.
