### PR TITLE
fix(widget): prevent crash when publishing widget previews

### DIFF
--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetPreviewPublisher.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetPreviewPublisher.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
+private const val TAG = "WidgetPreviewPublisher"
+
 /**
  * Publishes widget previews for the launcher widget picker (Android 15+).
  * Handles rate limiting by checking if preview is already published and tracking app version.
@@ -72,11 +74,11 @@ object WidgetPreviewPublisher {
             } catch (e: kotlinx.coroutines.CancellationException) {
                 throw e
             } catch (e: IllegalArgumentException) {
-                Log.e("WidgetPreview", "Failed to publish widget previews: system limit or invalid state", e)
+                Log.e(TAG, "Failed to publish widget previews: system limit or invalid state", e)
             } catch (e: android.os.RemoteException) {
-                Log.e("WidgetPreview", "Failed to publish widget previews: binder error", e)
+                Log.e(TAG, "Failed to publish widget previews: binder error", e)
             } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-                Log.e("WidgetPreview", "Failed to publish widget previews: unexpected error", e)
+                Log.e(TAG, "Failed to publish widget previews: unexpected error", e)
             }
         }
     }

--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetPreviewPublisher.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/widget/WidgetPreviewPublisher.kt
@@ -5,6 +5,7 @@ import android.appwidget.AppWidgetProviderInfo
 import android.content.ComponentName
 import android.content.Context
 import android.os.Build
+import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.collection.intSetOf
 import androidx.core.content.edit
@@ -57,15 +58,25 @@ object WidgetPreviewPublisher {
                 return@launch
             }
 
-            val result = GlanceAppWidgetManager(context)
-                .setWidgetPreviews(
-                    WledWidgetReceiver::class,
-                    intSetOf(AppWidgetProviderInfo.WIDGET_CATEGORY_HOME_SCREEN),
-                )
+            try {
+                val result = GlanceAppWidgetManager(context)
+                    .setWidgetPreviews(
+                        WledWidgetReceiver::class,
+                        intSetOf(AppWidgetProviderInfo.WIDGET_CATEGORY_HOME_SCREEN),
+                    )
 
-            // Only save version if successful (not rate-limited)
-            if (result == SET_WIDGET_PREVIEWS_RESULT_SUCCESS) {
-                prefs.edit { putInt(KEY_PREVIEW_VERSION, currentVersionCode) }
+                // Only save version if successful (not rate-limited)
+                if (result == SET_WIDGET_PREVIEWS_RESULT_SUCCESS) {
+                    prefs.edit { putInt(KEY_PREVIEW_VERSION, currentVersionCode) }
+                }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (e: IllegalArgumentException) {
+                Log.e("WidgetPreview", "Failed to publish widget previews: system limit or invalid state", e)
+            } catch (e: android.os.RemoteException) {
+                Log.e("WidgetPreview", "Failed to publish widget previews: binder error", e)
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Log.e("WidgetPreview", "Failed to publish widget previews: unexpected error", e)
             }
         }
     }


### PR DESCRIPTION
Fixes a frequent crash on Android 15+ devices occurring during widget preview publication.

The crash was caused by system-level exceptions (`IllegalArgumentException` and `RemoteException`) when calling `GlanceAppWidgetManager.setWidgetPreviews`, likely due to device-specific resource limits or profile locks.

## Changes
- Implemented robust error handling in `WidgetPreviewPublisher.kt` with specific catch blocks for `IllegalArgumentException` and `RemoteException`.
- Added a specific catch for `CancellationException` to ensure proper coroutine behavior.
- Added a fallback general `Exception` handler (with Detekt suppression) to prevent any other unforeseen binder failures from crashing the app.
- Ensures the system launcher falls back to the static widget preview if dynamic publication fails.

## Validation
- Verified that all static analysis checks (Detekt and Spotless) pass.
- Verified that the exception handling prevents the reported crashes while maintaining app stability.
