### PR TITLE
fix: Update MIME type handling in CustomWebChromeClient

### DIFF
--- a/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/components/DeviceWebview.kt
+++ b/app/src/main/java/ca/cgagnier/wlednativeandroid/ui/components/DeviceWebview.kt
@@ -389,13 +389,14 @@ class CustomWebChromeClient(private val context: Context) : WebChromeClient() {
 
     private fun getMimeType(acceptTypes: Array<String>): String {
         for (type in acceptTypes) {
-            return when (type) {
-                ".json" -> "application/json"
-                ".css" -> "text/css"
+            return when {
+                type == ".json" -> "application/json"
+                type == ".css" -> "text/css"
+                type.contains("/") -> type
                 else -> continue
             }
         }
-        return "application/octet-stream"
+        return "*/*"
     }
 }
 


### PR DESCRIPTION
> [!NOTE]
> Implemented by Copilot. I tested it on my phone.

Fixes https://github.com/Moustachauve/WLED-Android/issues/141

Previously it was loading a generic file picker with all files grayed out. 
Now it directly opens image picker in "Image Tool" and file picker in "Software Update" (that accepts any file type).

---

## Summary

- Fixed file picker showing all files as grayed out when uploading files through the WLED web UI
- `getMimeType()` now passes through any value already in `type/subtype` format (e.g. `image/*`, `image/jpeg`) directly to the file picker intent
- Changed the fallback MIME type from `application/octet-stream` to `*/*` so that all files are selectable when no specific type is recognised

## Motivation

WLED's web UI uses a standard HTML `<input type="file" accept="image/*">` element for image uploads. When this triggers the Android file chooser, the browser passes the `accept` attribute value (e.g. `image/*`) as-is in `FileChooserParams.acceptTypes`.

`getMimeType()` only handled two specific file extensions (`.json` → `application/json`, `.css` → `text/css`). Any other value — including valid MIME types like `image/*` — fell through the `when` expression and returned the hardcoded fallback `application/octet-stream`.

`Intent.ACTION_GET_CONTENT` uses the intent type to filter which files the user can select. When the type is `application/octet-stream`, the file picker renders images (and most other files) as grayed-out and non-selectable, because their actual MIME types do not match.

The fix recognises that any string containing `/` is already a valid MIME type and forwards it directly to the intent, so `image/*` correctly enables image selection. The fallback is also relaxed to `*/*` to keep all files accessible when the accept type is unknown.

## How to Test

1. Open the app and navigate to a WLED device.
2. In the device's web UI, go to **PixelForge → Image Tool** (or any page with a file upload input).
3. Tap the file upload button that expects an image.
4. Verify the system file picker opens and image files are **selectable** (not grayed out).
5. Select an image and confirm it uploads successfully.
